### PR TITLE
Added reboot azure stress test and fixed scripts

### DIFF
--- a/RunTests.ps1
+++ b/RunTests.ps1
@@ -167,7 +167,8 @@ try
             LogMsg "ResultDBTestTag: $ResultDBTestTag added to .\XML\GlobalConfigurations.xml"
         }                      
     }
-    $GlobalConfiguration.Save(".\XML\GlobalConfigurations.xml")
+    $xmlGlobalConfigPath = Resolve-Path -Path ".\XML\GlobalConfigurations.xml"
+    $GlobalConfiguration.Save($xmlGlobalConfigPath)
     #endregion
 
     New-Item -ItemType Directory -Path "TestResults" -Force -ErrorAction SilentlyContinue | Out-Null

--- a/Testscripts/Windows/STRESSTEST-VERIFY-RESTART.ps1
+++ b/Testscripts/Windows/STRESSTEST-VERIFY-RESTART.ps1
@@ -1,0 +1,94 @@
+$ErrorActionPreference = "Continue"
+
+function Main {
+    param(
+        [parameter(Mandatory=$true)]
+        [String] $Distro,
+        [parameter(Mandatory=$true)]
+        [xml] $XmlConfig
+    )
+
+    $result = ""
+    $testResult = ""
+    $resultArr = @()
+
+    $isDeployed = DeployVMS -setupType $currentTestData.setupType -Distro $Distro `
+        -xmlConfig $XmlConfig
+    if ($isDeployed) {
+        foreach ($param in $currentTestData.TestParameters.param) {
+            $paramName = $param.Split("=")[0]
+            $paramValue = $param.Split("=")[1]
+            if ($paramName -eq "rebootNumber") {
+                $rebootNumber = $paramValue
+            }
+        }
+        if (-not $rebootNumber) {
+            $rebootNumber = "1"
+        }
+        for ($rebootNr = 1; $rebootNr -le $rebootNumber; $rebootNr++) {
+            try {
+                $hs1VIP = $AllVMData.PublicIP
+                $hs1vm1sshport = $AllVMData.SSHPort
+                $hs1ServiceUrl = $AllVMData.URL
+                $hs1vm1Dip = $AllVMData.InternalIP
+                LogMsg ("Trying to restart {0}: {1} / {2} ..." `
+                    -f @($AllVMData.RoleName, $rebootNr, $rebootNumber))
+                $RestartStatus = RestartAllDeployments -allVMData $AllVMData
+                if ($RestartStatus -eq "True") {
+                    $isSSHOpened = isAllSSHPortsEnabledRG -AllVMDataObject $AllVMData
+                    if ($isSSHOpened -eq "True") {
+                        $isRestarted = $true
+                    } else {
+                        LogErr "VM is not available after restart"
+                        $isRestarted = $false
+                    }
+                } else {
+                    $isRestarted = $false
+                }
+                if ($isRestarted) {
+                    LogMsg "Virtual machine restart successful."
+                    $testResult = "PASS"
+                } else {
+                    LogErr "Virtual machine restart failed."
+                    $testResult = "FAIL"
+                    break
+                }
+            } catch {
+                $ErrorMessage =  $_.Exception.Message
+                LogMsg "EXCEPTION : $ErrorMessage"
+                break
+            } finally {
+                if (-not $testResult) {
+                    $testResult = "Aborted"
+                }
+                $resultArr += $testResult
+            }
+        }
+        LogMsg "Reboot Stress Test Result: $rebootNr/$rebootNumber"
+        if (($rebootNr - 1) -lt $rebootNumber) {
+            $testResult = "FAIL"
+        }
+    } else {
+        $testResult = "FAIL"
+        LogErr "The current deployment could not be found"
+        $resultArr += $testResult
+    }
+
+    $result = GetFinalResultHeader -resultarr $resultArr
+
+    # Clean up the setup
+    DoTestCleanUp -result $result -testName $currentTestData.testName `
+        -deployedServices $isDeployed -ResourceGroups $isDeployed
+
+    # Return the result and summary to the test suite script..
+    return $result
+}
+
+# Global Variables
+#
+# $currentTestData
+# $Distro
+# $XmlConfig
+# $AllVMData
+
+Main -Distro $Distro -XmlConfig $xmlConfig 

--- a/Utilities/UpdateGlobalConfigurationFromXmlSecrets.ps1
+++ b/Utilities/UpdateGlobalConfigurationFromXmlSecrets.ps1
@@ -10,8 +10,10 @@
 param(
     [string]$XmlSecretsFilePath= ""
 )
+
+$xmlGlobalConfigPath = Resolve-Path -Path ".\XML\GlobalConfigurations.xml"
 $XmlSecrets = [xml](Get-Content $XmlSecretsFilePath)
-$GlobalXML = [xml](Get-Content ".\XML\GlobalConfigurations.xml")
+$GlobalXML = [xml](Get-Content $xmlGlobalConfigPath)
 $GlobalXML.Global.Azure.Subscription.SubscriptionID = $XmlSecrets.secrets.SubscriptionID
 
 $GlobalXML.Global.Azure.TestCredentials.LinuxUsername = $XmlSecrets.secrets.linuxTestUsername
@@ -21,6 +23,6 @@ $GlobalXML.Global.Azure.ResultsDatabase.server = $XmlSecrets.secrets.DatabaseSer
 $GlobalXML.Global.Azure.ResultsDatabase.user = $XmlSecrets.secrets.DatabaseUser
 $GlobalXML.Global.Azure.ResultsDatabase.password = $XmlSecrets.secrets.DatabasePassword
 $GlobalXML.Global.Azure.ResultsDatabase.dbname = $XmlSecrets.secrets.DatabaseName
-$GlobalXML.Save(".\XML\GlobalConfigurations.xml")
+$GlobalXML.Save($xmlGlobalConfigPath)
 
 Write-Host "Updated GlobalConfigurations.xml"

--- a/XML/TestCases/StressTests.xml
+++ b/XML/TestCases/StressTests.xml
@@ -1,3 +1,17 @@
 <TestCases>
-
+    <test>
+        <testName>STRESSTEST-VERIFY-RESTART</testName>
+        <testScript></testScript>
+        <PowershellScript>STRESSTEST-VERIFY-RESTART.ps1</PowershellScript>
+        <files></files>
+        <setupType>SingleVM</setupType>
+        <TestParameters>
+            <param>rebootNumber=100</param>
+        </TestParameters>
+        <Platform>Azure</Platform>
+        <Category>STRESSTEST</Category>
+        <Area>stress</Area>
+        <Tags>stress,boot</Tags>
+        <TestID>AzureStress_001</TestID>
+    </test>
 </TestCases>


### PR DESCRIPTION
1. Added azure reboot stress test
2. Fixed xml save failure when a relative path is given as a parameter, for the following scripts:
RunTests.ps1
UpdateGlobalConfigurationFromXmlSecrets.ps1