### PR TITLE
Removal-Variable exception in final block

### DIFF
--- a/RunTests.ps1
+++ b/RunTests.ps1
@@ -498,12 +498,14 @@ finally
         Write-Host "Copying all files back to original working directory: $originalWorkingDirectory."
         $tmpDest = '\\?\' + $originalWorkingDirectory
         Copy-Item -Path "$finalWorkingDirectory\*" -Destination $tmpDest -Force -Recurse | Out-Null
-        cd ..
+        Set-Location ..
         Write-Host "Cleaning up $finalWorkingDirectory"
         Remove-Item -Path $finalWorkingDirectory -Force -Recurse -ErrorAction SilentlyContinue
         Write-Host "Setting workspace back to original location: $originalWorkingDirectory"
-        cd $originalWorkingDirectory
+        Set-Location $originalWorkingDirectory
     }
-    Get-Variable -Scope Global | Remove-Variable -Force -ErrorAction SilentlyContinue
+    Get-Variable -Exclude PWD,*Preference | Remove-Variable -Force -ErrorAction SilentlyContinue
     LogMsg "LISAv2 exits with code: $ExitCode"
-    exit $ExitCode}
+
+    exit $ExitCode
+}


### PR DESCRIPTION
Can not removal all global variables in live session, so it won't clear variables successfully. It shows other distro name in run-time log.  New fix tested in the same PS console, and verified no log string like "Distro Already Detected as : xxxxx"