### PR TITLE
azure: Trim ARMImageName value before usage and added unit simple tests to partially test the affected code

### DIFF
--- a/Libraries/Framework.psm1
+++ b/Libraries/Framework.psm1
@@ -32,11 +32,12 @@ Function ValidateParameters()
 		#region Validate Parameters
 		if ( !$ARMImageName -and !$OsVHD )
 		{
-			$ParameterErrors += "-ARMImageName <'Publisher Offer Sku Version'>, or -OsVHD <'VHD_Name.vhd'> is required."
+			$ParameterErrors += "-ARMImageName '<Publisher> <Offer> <Sku> <Version>', or -OsVHD <'VHD_Name.vhd'> is required."
 		}
-		if ($ARMImageName.Split(" ").Count -ne 4)
+		if ($ARMImageName.Trim().Split(" ").Count -ne 4)
 		{
-			$ParameterErrors += "Invalid value for -ARMImageName <'Publisher Offer Sku Version'> provided. 'Publisher Offer Sku Version' should be separated by space ' ' char."
+			$ParameterErrors += ("Invalid value for the provided ARMImageName parameter: <'${ARMImageName}'>." + `
+                                 "The ARM image should be in the format: '<Publisher> <Offer> <Sku> <Version>'.")
 		}
 		if ( !$TestLocation)
 		{

--- a/RunTests.ps1
+++ b/RunTests.ps1
@@ -170,7 +170,7 @@ try {
 	$TestXMLs = Get-ChildItem -Path "$WorkingDirectory\XML\TestCases\*.xml"
 	$SetupTypeXMLs = Get-ChildItem -Path "$WorkingDirectory\XML\VMConfigurations\*.xml"
 	$allTests = @()
-	$ARMImage = $ARMImageName.Split(" ")
+	$ARMImage = $ARMImageName.Trim().Split(" ")
 	$xmlFile = "$WorkingDirectory\TestConfiguration.xml"
 	if ( $TestCategory -eq "All")
 	{

--- a/UnitTests/PowerShell/Libraries.Azure.Tests.ps1
+++ b/UnitTests/PowerShell/Libraries.Azure.Tests.ps1
@@ -1,0 +1,18 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache License.
+#
+
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+$moduleName = "Azure"
+$modulePath = Join-Path $here "../../Libraries/${moduleName}.psm1"
+
+if (Get-Module $moduleName -ErrorAction SilentlyContinue) {
+    Remove-Module $moduleName
+}
+
+Describe "Test if module ${moduleName} is valid" {
+    It "Should load a valid module" {
+        { Import-Module $modulePath } | Should Not Throw
+    }
+}

--- a/UnitTests/PowerShell/Libraries.CommonFunctions.Tests.ps1
+++ b/UnitTests/PowerShell/Libraries.CommonFunctions.Tests.ps1
@@ -1,0 +1,18 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache License.
+#
+
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+$moduleName = "CommonFunctions"
+$modulePath = Join-Path $here "../../Libraries/${moduleName}.psm1"
+
+if (Get-Module $moduleName -ErrorAction SilentlyContinue) {
+    Remove-Module $moduleName
+}
+
+Describe "Test if module ${moduleName} is valid" {
+    It "Should load a valid module" {
+        { Import-Module $modulePath } | Should Not Throw
+    }
+}

--- a/UnitTests/PowerShell/Libraries.ExtensionLibrary.Tests.ps1
+++ b/UnitTests/PowerShell/Libraries.ExtensionLibrary.Tests.ps1
@@ -1,0 +1,18 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache License.
+#
+
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+$moduleName = "ExtensionLibrary"
+$modulePath = Join-Path $here "../../Libraries/${moduleName}.psm1"
+
+if (Get-Module $moduleName -ErrorAction SilentlyContinue) {
+    Remove-Module $moduleName
+}
+
+Describe "Test if module ${moduleName} is valid" {
+    It "Should load a valid module" {
+        { Import-Module $modulePath } | Should Not Throw
+    }
+}

--- a/UnitTests/PowerShell/Libraries.Framework.Tests.ps1
+++ b/UnitTests/PowerShell/Libraries.Framework.Tests.ps1
@@ -1,0 +1,18 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache License.
+#
+
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+$moduleName = "Framework"
+$modulePath = Join-Path $here "../../Libraries/${moduleName}.psm1"
+
+if (Get-Module $moduleName -ErrorAction SilentlyContinue) {
+    Remove-Module $moduleName
+}
+
+Describe "Test if module ${moduleName} is valid" {
+    It "Should load a valid module" {
+        { Import-Module $modulePath } | Should Not Throw
+    }
+}

--- a/UnitTests/PowerShell/Libraries.HyperV.Tests.ps1
+++ b/UnitTests/PowerShell/Libraries.HyperV.Tests.ps1
@@ -1,0 +1,18 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache License.
+#
+
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+$moduleName = "HyperV"
+$modulePath = Join-Path $here "../../Libraries/${moduleName}.psm1"
+
+if (Get-Module $moduleName -ErrorAction SilentlyContinue) {
+    Remove-Module $moduleName
+}
+
+Describe "Test if module ${moduleName} is valid" {
+    It "Should load a valid module" {
+        { Import-Module $modulePath } | Should Not Throw
+    }
+}

--- a/UnitTests/PowerShell/Libraries.Test-Framework.Tests.ps1
+++ b/UnitTests/PowerShell/Libraries.Test-Framework.Tests.ps1
@@ -1,0 +1,18 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache License.
+#
+
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+$moduleName = "Test-Framework"
+$modulePath = Join-Path $here "../../Libraries/${moduleName}.psm1"
+
+if (Get-Module $moduleName -ErrorAction SilentlyContinue) {
+    Remove-Module $moduleName
+}
+
+Describe "Test if module ${moduleName} is valid" {
+    It "Should load a valid module" {
+        { Import-Module $modulePath } | Should Not Throw
+    }
+}

--- a/UnitTests/PowerShell/Readme.md
+++ b/UnitTests/PowerShell/Readme.md
@@ -1,0 +1,48 @@
+# Run PowerShell Unit Tests with Pester
+
+Pester is a PowerShell library used for testing PowerShell code.
+
+Pester's GitHub page: https://github.com/pester/Pester
+
+## Install Pester
+
+Pester comes preinstalled in Windows 10.
+
+To install / update Pester on Windows >= 10:
+
+```powershell
+    Install-Module -Name Pester -Force -SkipPublisherCheck
+```
+
+## Create a unit test file
+
+A PowerShell Pester test file should have the suffix `.Tests.ps1`.
+
+The content of such a file should follow a classical BDD (Behaviorual Driven Deployment) test format.
+
+```powershell
+
+# Function under test
+function Get-Cookie ([string]$Name="*")
+{
+    $cookies = @(
+        @{ Name = 'Fudge' }
+        @{ Name = 'Fortune' }
+    )
+    $cookies | where { $_.Name -like $Name }
+}
+
+# Pester tests
+Describe 'Get-Cookie' {
+    It "Given no parameters, it lists both cookies" {
+       $cookies = Get-Cookie
+       $cookies.Count | Should Be 2
+    }
+}
+```
+
+## Run Pester
+
+```cmd
+    powershell.exe -NonInteractive {Invoke-Pester }
+```


### PR DESCRIPTION
ARMImageName parameter value may come with leading spaces,
which leads to errors in the ARM templates.

This patch makes sure that the ARMImageName value is properly
trimmed before any usage.