### PR TITLE
Correcting PR#125

### DIFF
--- a/Libraries/Framework.psm1
+++ b/Libraries/Framework.psm1
@@ -34,7 +34,7 @@ Function ValidateParameters()
 		{
 			$ParameterErrors += "-ARMImageName '<Publisher> <Offer> <Sku> <Version>', or -OsVHD <'VHD_Name.vhd'> is required."
 		}
-		if (($ARMImageName.Trim().Split(" ").Count -ne 4) -and !$OsVHD) 
+		if (($ARMImageName.Trim().Split(" ").Count -ne 4) -and ($ARMImageName -ne "")) 
 		{
 			$ParameterErrors += ("Invalid value for the provided ARMImageName parameter: <'${ARMImageName}'>." + `
                                  "The ARM image should be in the format: '<Publisher> <Offer> <Sku> <Version>'.")


### PR DESCRIPTION
The fix applied in PR#125 is wrong. 
It just hides the problem instead of fixing it. The bug is caused by the empty string in $ARMImageName. 

To resolve this issue, we need to add one more condition to if statement to check if $ARMImageName is empty string.
The new PR is created with correct fix.

PR execution has been verified.