### PR TITLE
Fixed non Microsoft blob access for kernel-devel rpms

### DIFF
--- a/Testscripts/Linux/customLISInstall.sh
+++ b/Testscripts/Linux/customLISInstall.sh
@@ -149,7 +149,7 @@ elif [ $DistroName == "CENTOS" -o $DistroName == "REDHAT" -o $DistroName == "FED
 	LISDir=`pwd`
 	LogMsg "Installing kernel-devel-${kernel} for LIS..."
 	# TODO - code refactoring should fix non Microsoft blob access
-	yum install -y "https://konkasoftpackages.blob.core.windows.net/linuxbinaries/kernel-devel-${kernel}.rpm" ~/build-CustomLIS.txt 2>&1
+	yum install -y "https://partnerpipelineshare.blob.core.windows.net/kernel-devel-rpms/kernel-devel-${kernel}.rpm" ~/build-CustomLIS.txt 2>&1
 	LogMsg "LIS is installing from this ${LISDir} branch..."
 	./*-hv-driver-install >> ~/build-CustomLIS.txt 2>&1
 	if [ $? -ne 0 ]; then


### PR DESCRIPTION
As discussed in the team, we are moving kernel-devel rpms to designated Microsoft storage account.