### PR TITLE
Fixed non Microsoft blob access for FIO test

### DIFF
--- a/Testscripts/Linux/perf_fio.sh
+++ b/Testscripts/Linux/perf_fio.sh
@@ -100,7 +100,7 @@ InstallFIO()
 		else
 			LogMsg "Error: Unknown SLES version"
 			UpdateTestState "TestAborted"
-			return 2			
+			exit 1			
 		fi
 		zypper addrepo $repositoryUrl
 		zypper --no-gpg-checks --non-interactive --gpg-auto-import-keys refresh
@@ -117,7 +117,7 @@ InstallFIO()
 			if [ $? -ne 0 ]; then
 				LogMsg "Error: Unable to install fio from source/rpm"
 				UpdateTestState "TestAborted"
-				return 3
+				exit 1
 			fi
 		else
 			LogMsg "Info: fio installed from repository"
@@ -130,7 +130,7 @@ InstallFIO()
 		LogMsg "Unknown Distro"
 		UpdateTestState "TestAborted"
 		UpdateSummary "Unknown Distro, test aborted"
-		return 1
+		exit 1
 	fi
 }
 
@@ -355,11 +355,6 @@ mountDir="/data"
 cd ${HOMEDIR}
 
 InstallFIO
-if [ $? -ne 0 ]; then
-	LogMsg "Error: fio installation failed.."
-	UpdateTestState "TestAborted"
-	exit 1
-fi
 
 #Creating RAID before triggering test
 CreateRAID0 ext4

--- a/Testscripts/Windows/PERF-STORAGE-MULTIDISK-RAID0-FIO.ps1
+++ b/Testscripts/Windows/PERF-STORAGE-MULTIDISK-RAID0-FIO.ps1
@@ -33,11 +33,8 @@ chmod +x perf_fio.sh
 . azuremodules.sh
 collect_VM_properties
 "@
-        # TODO - code refactoring should fix non Microsoft blob access
         $myString2 = @"
-wget https://konkaciwestus1.blob.core.windows.net/scriptfiles/JSON.awk
-wget https://konkaciwestus1.blob.core.windows.net/scriptfiles/gawk
-wget https://konkaciwestus1.blob.core.windows.net/scriptfiles/fio_jason_parser.sh
+wget https://partnerpipelineshare.blob.core.windows.net/binarytools/gawk
 chmod +x *.sh
 cp fio_jason_parser.sh gawk JSON.awk /root/FIOLog/jsonLog/
 cd /root/FIOLog/jsonLog/
@@ -47,7 +44,7 @@ chmod 666 /root/perf_fio.csv
 "@
         Set-Content "$LogDir\StartFioTest.sh" $myString
         Set-Content "$LogDir\ParseFioTestLogs.sh" $myString2        
-        RemoteCopy -uploadTo $testVMData.PublicIP -port $testVMData.SSHPort -files ".\$constantsFile,.\Testscripts\Linux\azuremodules.sh,.\Testscripts\Linux\perf_fio.sh,.\$LogDir\StartFioTest.sh,.\$LogDir\ParseFioTestLogs.sh" -username "root" -password $password -upload
+        RemoteCopy -uploadTo $testVMData.PublicIP -port $testVMData.SSHPort -files ".\$constantsFile,.\Testscripts\Linux\azuremodules.sh,.\Testscripts\Linux\perf_fio.sh,.\Testscripts\Linux\fio_jason_parser.sh,.\Testscripts\Linux\JSON.awk,.\$LogDir\StartFioTest.sh,.\$LogDir\ParseFioTestLogs.sh" -username "root" -password $password -upload
         RemoteCopy -uploadTo $testVMData.PublicIP -port $testVMData.SSHPort -files $currentTestData.files -username "root" -password $password -upload
         $out = RunLinuxCmd -ip $testVMData.PublicIP -port $testVMData.SSHPort -username "root" -password $password -command "chmod +x *.sh" -runAsSudo
         $testJob = RunLinuxCmd -ip $testVMData.PublicIP -port $testVMData.SSHPort -username "root" -password $password -command "./StartFioTest.sh" -RunInBackground -runAsSudo

--- a/Testscripts/Windows/PERF-STORAGE-MULTIDISK-RAID0-FIO.ps1
+++ b/Testscripts/Windows/PERF-STORAGE-MULTIDISK-RAID0-FIO.ps1
@@ -34,7 +34,6 @@ chmod +x perf_fio.sh
 collect_VM_properties
 "@
         $myString2 = @"
-wget https://partnerpipelineshare.blob.core.windows.net/binarytools/gawk
 chmod +x *.sh
 cp fio_jason_parser.sh gawk JSON.awk /root/FIOLog/jsonLog/
 cd /root/FIOLog/jsonLog/
@@ -44,7 +43,7 @@ chmod 666 /root/perf_fio.csv
 "@
         Set-Content "$LogDir\StartFioTest.sh" $myString
         Set-Content "$LogDir\ParseFioTestLogs.sh" $myString2        
-        RemoteCopy -uploadTo $testVMData.PublicIP -port $testVMData.SSHPort -files ".\$constantsFile,.\Testscripts\Linux\azuremodules.sh,.\Testscripts\Linux\perf_fio.sh,.\Testscripts\Linux\fio_jason_parser.sh,.\Testscripts\Linux\JSON.awk,.\$LogDir\StartFioTest.sh,.\$LogDir\ParseFioTestLogs.sh" -username "root" -password $password -upload
+        RemoteCopy -uploadTo $testVMData.PublicIP -port $testVMData.SSHPort -files ".\$constantsFile,.\$LogDir\StartFioTest.sh,.\$LogDir\ParseFioTestLogs.sh" -username "root" -password $password -upload
         RemoteCopy -uploadTo $testVMData.PublicIP -port $testVMData.SSHPort -files $currentTestData.files -username "root" -password $password -upload
         $out = RunLinuxCmd -ip $testVMData.PublicIP -port $testVMData.SSHPort -username "root" -password $password -command "chmod +x *.sh" -runAsSudo
         $testJob = RunLinuxCmd -ip $testVMData.PublicIP -port $testVMData.SSHPort -username "root" -password $password -command "./StartFioTest.sh" -RunInBackground -runAsSudo

--- a/XML/TestCases/PerformanceTests.xml
+++ b/XML/TestCases/PerformanceTests.xml
@@ -117,7 +117,7 @@
         <testScript>PERF-STORAGE-MULTIDISK-RAID0-FIO.ps1</testScript>
         <setupType>DS14DISK12</setupType>
         <SubtestValues>This-tag-will-be-removed</SubtestValues>
-        <files>.\Testscripts\Linux\azuremodules.sh</files>
+        <files>.\Testscripts\Linux\azuremodules.sh,.\Testscripts\Linux\perf_fio.sh,.\Testscripts\Linux\fio_jason_parser.sh,.\Testscripts\Linux\JSON.awk,.\Tools\gawk</files>
         <TestParameters>
             <param>modes='randread randwrite read write'</param>
             <param>startThread=1</param>
@@ -139,7 +139,7 @@
         <testScript>PERF-STORAGE-MULTIDISK-RAID0-FIO.ps1</testScript>
         <setupType>DS14DISK12</setupType>
         <SubtestValues>This-tag-will-be-removed</SubtestValues>
-        <files>.\Testscripts\Linux\azuremodules.sh</files>
+        <files>.\Testscripts\Linux\azuremodules.sh,.\Testscripts\Linux\perf_fio.sh,.\Testscripts\Linux\fio_jason_parser.sh,.\Testscripts\Linux\JSON.awk,.\Tools\gawk</files>
         <TestParameters>
             <param>modes='randread randwrite read write'</param>
             <param>startThread=1</param>


### PR DESCRIPTION
1. Binaries are moved to Microsoft designated storage account - partnerpipelineshare.
2. **[Urgent]** Fixed broken perf_fio.sh in LISAv2 master branch.