### PR TITLE
Updated the FIO VM size to Standard_DS14_v2

### DIFF
--- a/XML/VMConfigurations/PerformanceTestsConfigurations.xml
+++ b/XML/VMConfigurations/PerformanceTestsConfigurations.xml
@@ -244,8 +244,8 @@
         <ResourceGroup>
             <VirtualMachine>
                 <state></state>
-                <InstanceSize>Standard_DS14</InstanceSize>
-                <ARMInstanceSize>Standard_DS14</ARMInstanceSize>
+                <InstanceSize>Standard_DS14_v2</InstanceSize>
+                <ARMInstanceSize>Standard_DS14_v2</ARMInstanceSize>
                 <EndPoints>
                     <Name>SSH</Name>
                     <Protocol>tcp</Protocol>


### PR DESCRIPTION
Standard_DS14 size is being deprecated from lot of regions now.
This is resulting in test failure.