### PR TITLE
Fixed issue of LTP complete results are not being downloaded

### DIFF
--- a/Testscripts/Linux/Linux-Test-Project-Tests.sh
+++ b/Testscripts/Linux/Linux-Test-Project-Tests.sh
@@ -134,6 +134,11 @@ if grep FAIL "$LTP_OUTPUT" ; then
     echo "Failed Tests:" >> ~/summary.log
     grep FAIL "$LTP_OUTPUT" | cut -d':' -f 2- >> ~/summary.log
 fi
-
+echo "-----------LTP RESULTS----------------"
+cat $LTP_RESULTS >> ~/TestExecution.log
+echo "--------------------------------------"
+echo "-----------LTP OUTPUT----------------"
+cat $LTP_OUTPUT >> ~/TestExecution.log
+echo "--------------------------------------"
 SetTestStateCompleted
 exit 0


### PR DESCRIPTION
Copied the LTP result to "TestExecution.log" file which is by default downloaded by LISAv2 framework.