### PR TITLE
Corrected function name format suggestion

### DIFF
--- a/Documents/How-to-use.md
+++ b/Documents/How-to-use.md
@@ -148,7 +148,8 @@ Per Category, each XML file has VM name, Resource Group name, etc. We do not rec
         a. Log should be readable to reflect what’s happening in the test execution.
         b. Remove noise. Determine if it would be error or warning.
         c. Exception only in the case of fatal errors.
-    9. Recommended function name format - Function_Name(). Upper letter in each string connected with underscore character.
+    9. Recommended Bash & Python function name format - Function_Name(). Upper letter in each string connected
+        with underscore character. PowerShell function name format remains Verb-Entity() format like Get-VMSize().
 
 ## Support Contact
 


### PR DESCRIPTION
Keep the suggestion for bash and python while we keep the PS in Verb-Entity format.