### PR TITLE
Fixing the issue with RunLinuxCmd

### DIFF
--- a/Libraries/CommonFunctions.psm1
+++ b/Libraries/CommonFunctions.psm1
@@ -1438,7 +1438,8 @@ Function RemoteCopy($uploadTo, $downloadFrom, $downloadTo, $port, $files, $usern
 
 Function WrapperCommandsToFile([string] $username,[string] $password,[string] $ip,[string] $command, [int] $port)
 {
-    if ( ( $lastLinuxCmd -eq $command) -and ($lastIP -eq $ip) -and ($lastPort -eq $port) -and ($lastUser -eq $username) -and ($TestPlatform -eq "Azure"))
+    if ( ( $lastLinuxCmd -eq $command) -and ($lastIP -eq $ip) `-and ($lastPort -eq $port) `
+    -and ($lastUser -eq $username) -and ($TestPlatform -ne "HyperV"))
     {
         #Skip upload if current command is same as last command.
     }


### PR DESCRIPTION
Skip uploading of the runtest.sh file only if the test platform in not HyperV.
In case of HyperV, it must upload the runtest.sh file.

We've started working on AzureStack platform as well, which is similar to Azure. Hence, instead of explicitly checking for Azure, it is better to check for HypeV platform and instruct automation to upload runtest.sh file.