### PR TITLE
Typo fix in WrapperCommandsToFile

### DIFF
--- a/Libraries/CommonFunctions.psm1
+++ b/Libraries/CommonFunctions.psm1
@@ -1438,7 +1438,7 @@ Function RemoteCopy($uploadTo, $downloadFrom, $downloadTo, $port, $files, $usern
 
 Function WrapperCommandsToFile([string] $username,[string] $password,[string] $ip,[string] $command, [int] $port)
 {
-    if ( ( $lastLinuxCmd -eq $command) -and ($lastIP -eq $ip) `-and ($lastPort -eq $port) `
+    if ( ( $lastLinuxCmd -eq $command) -and ($lastIP -eq $ip) -and ($lastPort -eq $port) `
         -and ($lastUser -eq $username) -and ($TestPlatform -ne "HyperV"))
     {
         #Skip upload if current command is same as last command.


### PR DESCRIPTION
A small typo was introduced in my last PR which is causing the warning. Fixed it.