### PR TITLE
LTP tests updated to use latest release version

### DIFF
--- a/Testscripts/Linux/Linux-Test-Project-Tests.sh
+++ b/Testscripts/Linux/Linux-Test-Project-Tests.sh
@@ -26,10 +26,6 @@
 # Source constants file and initialize most common variables
 UtilsInit
 
-# define regular stable releases in order to avoid unstable builds
-# https://github.com/linux-test-project/ltp/tags
-ltp_version="20170929"
-
 TOP_BUILDDIR="/opt/ltp"
 TOP_SRCDIR="$HOME/src"
 LTP_RESULTS="$HOME/ltp-results.log"
@@ -91,12 +87,18 @@ esac
 test -d "$TOP_SRCDIR" || mkdir -p "$TOP_SRCDIR"
 cd "$TOP_SRCDIR"
 
+# define regular stable releases in order to avoid unstable builds
+# https://github.com/linux-test-project/ltp/tags
+# 'ltp_version_git_tag' is passed from Test Definition in .\XML\TestCases\CommunityTests.xml. 
+# 'ltp_version_git_tag' default value is defined in .\XML\Other\ReplaceableTestParameters.xml
+# You can run the ltp test with any tag using LISAv2's Custom Parameters feature.
+#   Syntax: RunTests.ps1 -CustomParameters "LTP_TESTS_GIT_TAG=new_tag"
 LogMsg "Cloning LTP"
 git clone https://github.com/linux-test-project/ltp.git
 TOP_SRCDIR="${HOME}/src/ltp"
 
 cd "$TOP_SRCDIR"
-git checkout tags/$ltp_version
+git checkout tags/$ltp_version_git_tag
 
 LogMsg "Configuring LTP..."
 # use autoreconf to match the installed package versions

--- a/XML/Other/ReplaceableTestParameters.xml
+++ b/XML/Other/ReplaceableTestParameters.xml
@@ -43,4 +43,8 @@ Scenario 2 : You need to run all the performance tests quickly.
         <ReplaceThis>DPDK_TEST_DURATION_IN_SECONDS</ReplaceThis>
         <ReplaceWith>120</ReplaceWith>
     </Parameter>
+    <Parameter>
+        <ReplaceThis>LTP_TESTS_GIT_TAG</ReplaceThis>
+        <ReplaceWith>20180515</ReplaceWith>
+    </Parameter>
 </ReplaceableTestParameters>

--- a/XML/TestCases/CommunityTests.xml
+++ b/XML/TestCases/CommunityTests.xml
@@ -70,6 +70,7 @@
         <setupType>LTP</setupType>
 		<TestParameters>
             <param>TC_COVERED=LTP-01</param>
+            <param>ltp_version_git_tag="LTP_TESTS_GIT_TAG"</param>
         </TestParameters>
         <SubtestValues>This-tag-will-be-removed</SubtestValues>      
         <Timeout>7200</Timeout>


### PR DESCRIPTION
Now, LTP tests can also be executed against any "git tag" using -CustomParameters feature.