### PR TITLE
Combined test result and execution time in one line

### DIFF
--- a/AzureTestSuite.ps1
+++ b/AzureTestSuite.ps1
@@ -112,6 +112,7 @@ Function RunTestsOnCycle ($cycleName , $xmlConfig, $Distro, $TestIterations ) {
 
 	$testCount = $currentCycleData.test.Length
 	$testIndex = 0
+	$SummaryHeaderAdded = $false
 	if (-not $testCount) {
 		$testCount = 1
 	}
@@ -197,8 +198,12 @@ Function RunTestsOnCycle ($cycleName , $xmlConfig, $Distro, $TestIterations ) {
 						$executionCount += 1
 						$testRunDuration = GetStopWatchElapasedTime $stopWatch "mm"
 						$testRunDuration = $testRunDuration.ToString()
-						$testCycle.emailSummary += "$($currentTestData.testName) Execution Time: $testRunDuration minutes<br />"
-						$testCycle.emailSummary += "	$($currentTestData.testName) : $($testResult)  <br />"
+						if ( -not $SummaryHeaderAdded ) {
+							$testCycle.emailSummary += "#Sr. Test Name : Test Result : Test Duration (in minutes)<br />"
+							$testCycle.emailSummary += "----------------------------------------------------<br />"
+							$SummaryHeaderAdded = $true
+						}
+						$testCycle.emailSummary += "$executionCount. $($currentTestData.testName) : $($testResult) : $testRunDuration<br />"
 						if ( $testSummary ) {
 							$testCycle.emailSummary += "$($testSummary)"
 						}

--- a/Libraries/CommonFunctions.psm1
+++ b/Libraries/CommonFunctions.psm1
@@ -2023,11 +2023,11 @@ Function CreateResultSummary($testResult, $checkValues, $testName, $metaData)
 {
 	if ( $metaData )
 	{
-		$resultString = "			$metaData : $testResult <br />"
+		$resultString = "	$metaData : $testResult <br />"
 	}
 	else
 	{
-		$resultString = "			$testResult <br />"
+		$resultString = "	$testResult <br />"
 	}
 	return $resultString
 }


### PR DESCRIPTION
Test summary now has following changes -

1. Header line
2. Sr. no. for each test case
3. Execution time is mentioned same line with test result (as requested by Simon)