### PR TITLE
fix: Changed hvServer as required by PR208

### DIFF
--- a/Testscripts/Windows/SETUP-Inject-IP-Constants.ps1
+++ b/Testscripts/Windows/SETUP-Inject-IP-Constants.ps1
@@ -164,5 +164,5 @@ function Main {
     return $true
 }
 
-Main -VMName $AllVMData.RoleName -hvServer $xmlConfig.config.Hyperv.Host.ServerName `
+Main -VMName $AllVMData.RoleName -hvServer $xmlConfig.config.Hyperv.Hosts.ChildNodes[0].ServerName `
     -VMPort $AllVMData.SSHPort -VMUserName $user -VMPassword $password

--- a/Testscripts/Windows/SETUP-NET-Add-Max-NIC.ps1
+++ b/Testscripts/Windows/SETUP-NET-Add-Max-NIC.ps1
@@ -107,5 +107,5 @@ function Main {
     return $True
 }
 
-Main -VMName $AllVMData.RoleName -HvServer $xmlConfig.config.Hyperv.Host.ServerName `
+Main -VMName $AllVMData.RoleName -HvServer $xmlConfig.config.Hyperv.Hosts.ChildNodes[0].ServerName `
          -TestParams $TestParams

--- a/Testscripts/Windows/SETUP-NET-Add-NIC.ps1
+++ b/Testscripts/Windows/SETUP-NET-Add-NIC.ps1
@@ -131,5 +131,5 @@ function Main {
     return $retVal
 }
 
-Main -VMName $AllVMData.RoleName -hvServer $xmlConfig.config.Hyperv.Host.ServerName `
+Main -VMName $AllVMData.RoleName -hvServer $xmlConfig.config.Hyperv.Hosts.ChildNodes[0].ServerName `
          -TestParams $TestParams

--- a/Testscripts/Windows/SETUP-NET-Switch-NIC.ps1
+++ b/Testscripts/Windows/SETUP-NET-Switch-NIC.ps1
@@ -95,5 +95,5 @@ function Main {
     return $retVal
 }
 
-Main -VMName $AllVMData.RoleName -hvServer $xmlConfig.config.Hyperv.Host.ServerName `
+Main -VMName $AllVMData.RoleName -hvServer $xmlConfig.config.Hyperv.Hosts.ChildNodes[0].ServerName `
          -TestParams $TestParams


### PR DESCRIPTION
PR208 introduced a change that makes the use of
$xmlConfig.config.Hyperv.Host.ServerName deprecated. It has been
replaced with $xmlConfig.config.Hyperv.Hosts.ChildNodes[0].ServerName