### PR TITLE
hyperv: Added VMBus tests

### DIFF
--- a/Testscripts/Linux/KDUMP-Config.sh
+++ b/Testscripts/Linux/KDUMP-Config.sh
@@ -1,0 +1,341 @@
+#!/bin/bash
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache License.
+
+kdump_conf=/etc/kdump.conf
+dump_path=/var/crash
+sys_kexec_crash=/sys/kernel/kexec_crash_loaded
+kdump_sysconfig=/etc/sysconfig/kdump
+boot_filepath=""
+
+#
+# Source utils.sh to get more utils
+# Get $DISTRO, LogMsg directly from utils.sh
+#
+. utils.sh || {
+    echo "unable to source utils.sh!"
+    exit 0
+}
+
+#
+# Source constants file and initialize most common variables
+#
+UtilsInit
+
+Install_Kexec(){
+    GetDistro
+    case $DISTRO in
+        centos* | redhat* | fedora*)
+            yum_install kexec-tools kdump-tools makedumpfile
+            if [ $? -ne 0 ]; then
+                UpdateSummary "Warning: Kexec-tools failed to install."
+            fi
+        ;;
+        ubuntu* | debian*)
+            export DEBIAN_FRONTEND=noninteractive
+            apt-get update; apt_get_install kexec-tools kdump-tools makedumpfile
+            if [ $? -ne 0 ]; then
+                UpdateSummary "Warning: Kexec-tools failed to install."
+            fi
+        ;;
+        suse*)
+            zypper refresh; zypper_install kexec-tools kdump makedumpfile
+            if [ $? -ne 0 ]; then
+                UpdateSummary "Warning: Kexec-tools failed to install."
+            fi
+        ;;
+        *)
+            LogErr "Warning: Distro '${distro}' not supported. Kexec-tools failed to install."
+        ;;
+    esac
+}
+
+Rhel_Extra_Settings(){
+    LogMsg "Adding extra kdump parameters(Rhel)..."
+
+    to_be_updated=(
+            'core_collector makedumpfile'
+            'disk_timeout'
+            'blacklist'
+            'extra_modules'
+        )
+    value=(
+        '-c --message-level 1 -d 31'
+        '100'
+        'hv_vmbus hv_storvsc hv_utils hv_netvsc hid-hyperv hyperv_fb hyperv-keyboard'
+        'ata_piix sr_mod sd_mod'
+        )
+
+    for (( item=0; item<${#to_be_updated[@]-1}; item++))
+    do
+        sed -i "s/${to_be_updated[item]}.*/#${to_be_updated[item]} ${value[item]}/g" $kdump_conf
+        echo "${to_be_updated[item]} ${value[item]}" >> $kdump_conf
+    done
+
+    kdump_commandline=(
+        'irqpoll'
+        'maxcpus='
+        'reset_devices'
+        'ide_core.prefer_ms_hyperv='
+    )
+    value_kdump=(
+        ''
+        '1'
+        ''
+        '0'
+    )
+
+    kdump_commandline_arguments=$(grep KDUMP_COMMANDLINE_APPEND $kdump_sysconfig |  sed 's/KDUMP_COMMANDLINE_APPEND="//g' | sed 's/"//g')
+    for (( item=0; item<${#kdump_commandline[@]-1}; item++))
+    do
+        if [ $? -eq 0 ]; then
+            kdump_commandline_arguments=$(echo ${kdump_commandline_arguments} | sed "s/${kdump_commandline[item]}\S*//g")
+        fi
+        kdump_commandline_arguments="$kdump_commandline_arguments ${kdump_commandline[item]}${value_kdump[item]}"
+    done
+
+    sed -i "s/KDUMP_COMMANDLINE_APPEND.*/KDUMP_COMMANDLINE_APPEND=\"$kdump_commandline_arguments\"/g" $kdump_sysconfig
+}
+
+Config_Rhel()
+{
+    # Modifying kdump.conf settings
+    LogMsg "Configuring kdump (Rhel)..."
+
+    sed -i '/^path/ s/path/#path/g' $kdump_conf
+    if [ $? -ne 0 ]; then
+        LogErr "Failed to comment path in /etc/kdump.conf. Probably kdump is not installed."
+        SetTestStateAborted
+        exit 0
+    else
+        echo path $dump_path >> $kdump_conf
+        LogMsg "Success: Updated the path to /var/crash."
+    fi
+
+    sed -i '/^default/ s/default/#default/g' $kdump_conf
+    if [ $? -ne 0 ]; then
+        LogErr "Failed to comment default behaviour in /etc/kdump_conf. Probably kdump is not installed."
+        SetTestStateAborted
+        exit 0
+    else
+        echo 'default reboot' >>  $kdump_conf
+        UpdateSummary "Success: Updated the default behaviour to reboot."
+    fi
+
+    if [[ -z "$os_RELEASE" ]]; then
+        GetOSVersion
+    fi
+
+    # Extra config for RHEL5 RHEL6.1 RHEL6.2
+    if [[ $os_RELEASE.$os_UPDATE =~ ^5.* ]] || [[ $os_RELEASE.$os_UPDATE =~ ^6.[0-2][^0-9] ]] ; then
+        Rhel_Extra_Settings
+    # Extra config for WS2012 - RHEL6.3+
+    elif [[ $os_RELEASE.$os_UPDATE =~ ^6.* ]] && [[ $BuildNumber == "9200" ]] ; then
+        echo "extra_modules ata_piix sr_mod sd_mod" >> /etc/kdump.conf
+        echo "options ata_piix prefer_ms_hyperv=0" >> /etc/kdump.conf
+        echo "blacklist hv_vmbus hv_storvsc hv_utils hv_netvsc hid-hyperv" >> /etc/kdump.conf
+        echo "disk_timeout 100" >> /etc/kdump.conf
+    fi
+
+    # Extra config for WS2012 - RHEL7
+    if [[ $os_RELEASE.$os_UPDATE =~ ^7.* ]] && [[ $BuildNumber == "9200" ]] ; then
+        echo "extra_modules ata_piix sr_mod sd_mod" >> /etc/kdump.conf
+        echo "KDUMP_COMMANDLINE_APPEND=\"ata_piix.prefer_ms_hyperv=0 disk_timeout=100 rd.driver.blacklist=hv_vmbus,hv_storvsc,hv_utils,hv_netvsc,hid-hyperv,hyperv_fb\"" >> /etc/sysconfig/kdump
+    fi
+
+    GetGuestGeneration
+
+    if [ $os_GENERATION -eq 2 ] && [[ $os_RELEASE =~ 6.* ]]; then
+        boot_filepath=/boot/efi/EFI/BOOT/bootx64.conf
+    elif [ $os_GENERATION -eq 1 ] && [[ $os_RELEASE =~ 6.* ]]; then
+        boot_filepath=/boot/grub/grub.conf
+    elif [ $os_GENERATION -eq 1 ] && [[ $os_RELEASE =~ 7.* || $os_RELEASE =~ 8.* ]]; then
+        boot_filepath=/boot/grub2/grub.cfg
+    elif [ $os_GENERATION -eq 2 ] && [[ $os_RELEASE =~ 7.* || $os_RELEASE =~ 8.* ]]; then
+        boot_filepath=/boot/efi/EFI/redhat/grub.cfg
+    else
+        boot_filepath=`find /boot -name grub.cfg`
+    fi
+
+    # Enable kdump service
+    LogMsg "Enabling kdump"
+
+    chkconfig kdump on --level 35
+    if [ $? -ne 0 ]; then
+        LogErr "Failed to enable kdump."
+        SetTestStateAborted
+        exit 0
+    else
+        UpdateSummary "Success: kdump enabled."
+    fi
+
+    # Configure to dump file on nfs server if it is the case
+    if [ $vm2ipv4 ] && [ $vm2ipv4 != "" ]; then
+        yum_install nfs-utils
+        if [ $? -ne 0 ]; then
+            LogErr "Failed to install nfs."
+            SetTestStateAborted
+            exit 0
+        fi
+        # Kdump configuration differs from RHEL 6 to RHEL 7
+        if [ $os_RELEASE -le 6 ]; then
+            echo "nfs $vm2ipv4:/mnt" >> /etc/kdump.conf
+            if [ $? -ne 0 ]; then
+                LogErr "Failed to configure kdump to use nfs."
+                SetTestStateAborted
+                exit 0
+            fi
+        else
+            echo "dracut_args --mount \"$vm2ipv4:/mnt /var/crash nfs defaults\"" >> /etc/kdump.conf
+            if [ $? -ne 0 ]; then
+                LogErr "Failed to configure kdump to use nfs."
+                SetTestStateAborted
+                exit 0
+            fi
+        fi
+
+        service kdump restart
+        if [ $? -ne 0 ]; then
+            LogErr "Failed to restart Kdump."
+            SetTestStateAborted
+            exit 0
+        fi
+    fi
+}
+
+Config_Sles()
+{
+    LogMsg "Configuring kdump (Sles)..."
+
+    if [[ -d /boot/grub2 ]]; then
+        boot_filepath='/boot/grub2/grub.cfg'
+    elif [[ -d /boot/grub ]]; then
+        boot_filepath='/boot/grub/menu.lst'
+    fi
+
+    LogMsg "Enabling kdump"
+    
+    chkconfig boot.kdump on
+    if [ $? -ne 0 ]; then
+        systemctl enable kdump.service
+        if [ $? -ne 0 ]; then
+            LogErr "FAILED to enable kdump."
+            SetTestStateAborted
+            exit 0
+        else
+            UpdateSummary "Success: kdump enabled."
+        fi
+    else
+        UpdateSummary "Success: kdump enabled."
+    fi
+
+    if [ $vm2ipv4 ] && [ $vm2ipv4 != "" ]; then
+        zypper_install nfs-client
+        if [ $? -ne 0 ]; then
+            LogErr "Failed to install nfs."
+            SetTestStateAborted
+            exit 0
+        fi
+        sed -i 's\KDUMP_SAVEDIR="/var/crash"\KDUMP_SAVEDIR="nfs://'"$vm2ipv4"':/mnt"\g' /etc/sysconfig/kdump
+        service kdump restart
+    fi
+}
+
+Config_Debian()
+{
+    boot_filepath="/boot/grub/grub.cfg"
+    LogMsg "Configuring kdump (Ubuntu)..."
+    UpdateSummary "Configuring kdump (Ubuntu)..."
+    sed -i 's/USE_KDUMP=0/USE_KDUMP=1/g' /etc/default/kdump-tools
+    grep -q "USE_KDUMP=1" /etc/default/kdump-tools
+    if [ $? -ne 0 ]; then
+        LogErr "kdump-tools are not existent or cannot be modified."
+        SetTestStateAborted
+        exit 0
+    fi
+
+    # Additional params needed
+    sed -i 's/LOAD_KEXEC=true/LOAD_KEXEC=false/g' /etc/default/kexec
+
+    # Configure to dump file on nfs server if it is the case
+    apt-get update -y
+    sleep 10
+
+    if [ $vm2ipv4 ] && [ $vm2ipv4 != "" ]; then
+        apt_get_install nfs-kernel-server
+        if [ $? -ne 0 ]; then
+            LogErr "Failed to install nfs."
+            SetTestStateAborted
+            exit 0
+        fi
+
+        apt_get_install nfs-common
+        if [ $? -ne 0 ]; then
+            LogErr "Failed to install nfs-common."
+            SetTestStateAborted
+            exit 0
+        fi
+        echo "NFS=\"$vm2ipv4:/mnt\"" >> /etc/default/kdump-tools
+        service kexec restart
+    fi
+}
+
+#######################################################################
+#
+# Main script body
+#
+#######################################################################
+
+if [ "$crashkernel" == "" ];then
+    LogErr "crashkernel parameter is null."
+    SetTestStateAborted
+    exit 0
+fi
+LogMsg "INFO: crashkernel=$crashkernel; vm2ipv4=$vm2ipv4"
+#
+# Checking the negotiated VMBus version
+#
+vmbus_string=`dmesg | grep "Vmbus version:"`
+
+if [ "$vmbus_string" = "" ]; then
+    LogMsg "WARNING: Negotiated VMBus version is not 3.0. Kernel might be old or patches not included."
+    LogMsg "Test will continue but it might not work properly."
+    UpdateSummary "WARNING: Full support for kdump is not present, test execution might not work as expected"
+fi
+
+Install_Kexec
+
+#
+# Configure kdump - this has distro specific behaviour
+#
+GetDistro
+
+if [[ "$OS_FAMILY" == "Debian" ]] || [[ "$OS_FAMILY" == "Sles" ]] || \
+    [[ "$DISTRO" == "fedora"* ]] && [[ "$crashkernel" == "auto" ]];then
+    LogErr "crashkernel=auto doesn't work for this distro. Please use this pattern: crashkernel=X@Y."
+    SetTestStateAborted
+    exit 0
+fi
+
+Config_${OS_FAMILY}
+
+# Remove old crashkernel params
+sed -i "s/crashkernel=\S*//g" $boot_filepath
+
+# Remove console params; It could interfere with the testing
+sed -i "s/console=\S*//g" $boot_filepath
+
+# Add the crashkernel param
+sed -i "/vmlinuz-`uname -r`/ s/$/ crashkernel=$crashkernel/" $boot_filepath
+if [ $? -ne 0 ]; then
+    LogErr "Could not set the new crashkernel value in $boot_filepath"
+    SetTestStateAborted
+    exit 0
+else
+    LogMsg "Success: updated the crashkernel value to: $crashkernel."
+fi
+
+# Cleaning up any previous crash dump files
+mkdir -p /var/crash
+rm -rf /var/crash/*
+SetTestStateCompleted

--- a/Testscripts/Linux/utils.sh
+++ b/Testscripts/Linux/utils.sh
@@ -227,8 +227,9 @@ UpdateSummary()
 }
 
 
-# Function to get current distro
+# Function to get current distro and distro family
 # Sets the $DISTRO variable to one of the following: suse, centos_{5, 6, 7}, redhat_{5, 6, 7}, fedora, ubuntu
+# Sets the $OS_FAMILY variable to one of the following: Rhel, Debian, Suse
 # The naming scheme will be distroname_version
 # Takes no arguments
 
@@ -319,6 +320,21 @@ GetDistro()
 			DISTRO=unknown
 			return 1
 			;;
+	esac
+	case $DISTRO in
+		centos* | redhat* | fedora*)
+			OS_FAMILY="Rhel"
+		;;
+		ubuntu* | debian*)
+			OS_FAMILY="Debian"
+		;;
+		suse*)
+			OS_FAMILY="Sles"
+		;;
+		*)
+			OS_FAMILY="unknown"
+			return 1
+		;;
 	esac
 
 	return 0

--- a/Testscripts/Linux/verify_vmbus_interrupts.sh
+++ b/Testscripts/Linux/verify_vmbus_interrupts.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache License.
+
+########################################################################
+#
+# Description:
+#    This script was created to automate the testing of a Linux
+#    Integration services. This script will verify if all the CPUs 
+#    inside a Linux VM are processing VMBus interrupts, by checking 
+#    the /proc/interrupts file.
+#
+#    The test performs the following steps:
+#        1. Looks for the Hyper-v timer property of each CPU under /proc/interrupts
+#        2. Verifies if each CPU has more than 0 interrupts processed.
+#     
+################################################################
+
+# Source utils.sh
+. utils.sh || {
+    echo "ERROR: unable to source utils.sh!"
+    echo "TestAborted" > state.txt
+    exit 0
+}
+
+# Source constants file and initialize most common variables
+UtilsInit
+
+function verify_vmbus_interrupts() {
+
+    nonCPU0inter=0
+    cpu_count=$(grep CPU -o /proc/interrupts | wc -l)
+    UpdateSummary "${cpu_count} CPUs found"
+
+    #
+    # It is not mandatory to have the Hyper-V interrupts present
+    # Skip test execution if these are not showing up
+    #
+    if ! [[ $(grep 'hyperv\|Hypervisor' /proc/interrupts) ]]; then
+        UpdateSummary "Hyper-V interrupts are not recorded, abort test."
+        SetTestStateAborted
+        exit 0
+    fi
+
+    #
+    # Verify if VMBUS interrupts are processed by all CPUs
+    #
+    while read line
+    do
+        if [[ ($line = *hyperv* ) || ( $line = *Hypervisor* ) ]]; then
+            for (( core=0; core<=$cpu_count-1; core++ ))
+            do
+                intrCount=`echo $line | cut -f $(( $core+2 )) -d ' '`
+                if [ $intrCount -ne 0 ]; then
+                    (( nonCPU0inter++ ))
+                    UpdateSummary "CPU core ${core} is processing VMBUS interrupts."
+                fi
+            done
+        fi
+    done < "/proc/interrupts"
+
+    if [ $nonCPU0inter -ne $cpu_count ]; then
+        LogErr "Not all CPU cores are processing VMBUS interrupts!"
+        SetTestStateFailed
+        exit 0
+    fi
+
+    UpdateSummary "All {$cpu_count} CPU cores are processing interrupts."
+    SetTestStateCompleted
+}
+
+verify_vmbus_interrupts

--- a/Testscripts/Linux/verify_vmbus_protocol_version.sh
+++ b/Testscripts/Linux/verify_vmbus_protocol_version.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache License.
+
+########################################################################
+#
+## Description:
+#       This script was created to automate the testing of a Linux
+#       Integration services. This script will verify that the
+#       VMBus protocol string is identified and present in Linux.
+#       This is available only for Windows Server 2012 R2 and newer.
+#       Windows Server 2012 R2 VMBus protocol version is 2.4, newer
+#       Linux kernels have VMBus protocol version 3.0.
+#
+#       The test performs the following steps:
+#         1. Looks for the VMBus protocol tag inside the dmesg log.
+#
+#
+################################################################
+
+# Source utils.sh
+. utils.sh || {
+    echo "ERROR: unable to source utils.sh!"
+    echo "TestAborted" > state.txt
+    exit 0
+}
+
+# Source constants file and initialize most common variables
+UtilsInit
+
+function verify_vmbus_protocol_version() {
+    #
+    # Checking for the VMBus protocol string in dmesg
+    #
+    vmbus_string=$(dmesg | grep -oE '*hv_vmbus.*Vmbus.*version.*')
+    if [[ "$vmbus_string" == "" ]]; then
+        UpdateSummary "Could not find the VMBus protocol string in dmesg."
+        SetTestStateFailed
+        exit 0
+    fi
+    UpdateSummary "Found a matching VMBus string: ${vmbus_string}"
+    SetTestStateCompleted
+}
+
+verify_vmbus_protocol_version

--- a/Testscripts/Windows/Check-VMBusPanicEvent.ps1
+++ b/Testscripts/Windows/Check-VMBusPanicEvent.ps1
@@ -1,0 +1,182 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache License.
+<#
+.Synopsis
+    Verify the Hyper-V host logs a 18590 event in the Hyper-V-Worker-Admin
+    event log when the Linux guest panics.
+.Description
+    The Linux kernel allows a driver to register a Panic Notifier handler
+    which will be called if the Linux kernel panics.  The hv_vmbus driver
+    registers a panic notifier handler.  When this handler is called, it
+    will write to the Hyper-V crash MSR registers.  This results in the
+    Hyper-V host logging a 18590 event in the Hyper-V-Worker-Admin event
+    log.
+
+.Parameter testParams
+    Test data for this test case
+#>
+param([String] $TestParams)
+
+$ErrorActionPreference = "Stop"
+
+function Get-VMPanicEvent {
+    param(
+        $VMName,
+        $HvServer,
+        $StartTime,
+        $RetryCount=30,
+        $RetryInterval=5
+    )
+
+    $currentRetryCount = 0
+    $testPassed = $false
+    while ($currentRetryCount -lt $RetryCount -and !$testPassed) {
+        LogMsg "Checking eventlog for 18590 event sent by VM ${VMName}"
+        $currentRetryCount++
+        $events = @(Get-WinEvent -FilterHashTable `
+            @{LogName = "Microsoft-Windows-Hyper-V-Worker-Admin";
+              StartTime = $prePanicTime} `
+            -ComputerName $hvServer -ErrorAction SilentlyContinue)
+        foreach ($evt in $events) {
+            if ($evt.id -eq 18590 -and $evt.message.Contains($vmName)) {
+                $testPassed = $true
+                break
+            }
+        }
+        Start-Sleep $RetryInterval
+    }
+    return $testPassed
+}
+
+function Wait-VMState {
+    param(
+        $VMName,
+        $VMState,
+        $HvServer,
+        $RetryCount=30,
+        $RetryInterval=5
+    )
+
+    $offStateRetryCount = 0
+    while ($offStateRetryCount -lt $RetryCount -and `
+              (Get-VM -ComputerName $hvServer -Name $vmName).State -ne $VMState) {
+        LogMsg "Waiting for VM ${VMName} to enter ${VMState} state"
+        Start-Sleep -Seconds $RetryInterval
+        $offStateRetryCount++
+    }
+    if ($offStateRetryCount -eq $RetryCount) {
+        throw "VM ${VMName} failed to enter ${VMState} state"
+    }
+}
+
+function Wait-VMHeartbeatOK {
+    param(
+        $VMName,
+        $HvServer,
+        $RetryCount=30,
+        $RetryInterval=5
+    )
+
+    $offStateRetryCount = 0
+    do {
+        $offStateRetryCount++
+        Start-Sleep -Seconds $RetryInterval
+        LogMsg "Waiting for VM ${VMName} to enter Heartbeat OK state"
+    } until ($offStateRetryCount -ge $RetryCount -or `
+                 (Get-VMIntegrationService -VMName $vmName -ComputerName $hvServer | `
+                  Where-Object  { $_.name -eq "Heartbeat" }
+              ).PrimaryStatusDescription -eq "OK")
+    if ($offStateRetryCount -eq $RetryCount) {
+        throw "VM ${VMName} failed to enter Heartbeat OK state"
+    }
+}
+
+
+function Check-VMBusPanicEvent {
+    param(
+        $VMName,
+        $HvServer,
+        $Ipv4,
+        $VMPort,
+        $VMUsername,
+        $VMPassword,
+        $TestParams,
+        $LogDir
+    )
+
+    LogMsg "Check minimum host build number"
+    $buildNumber = Get-HostBuildNumber $hvServer
+    if (!$buildNumber) {
+        return "FAIL"
+    }
+    if ($BuildNumber -lt 9600) {
+        return "ABORTED"
+    }
+
+    LogMsg "Make sure the VM is started"
+    Start-VM -ComputerName $hvServer -Name $vmName
+    Wait-VMState -VMName $VMName -HvServer $HvServer -VMState "Running"
+
+    LogMsg "Make sure kdump is configured on the VM"
+    if ($TestParams.ENABLE_KDUMP -eq "true") {
+        $installKdumpFile = "KDUMP-Config.sh"
+        $installKdumpScript = "echo '${VMPassword}' | sudo -S -s eval `"export HOME=``pwd``;bash ${installKdumpFile} > install_kdump.log`""
+        $installKdumpLog = "/home/${VMUserName}/install_kdump.log"
+        RunLinuxCmd -username $VMUserName -password $VMPassword `
+                    -ip $Ipv4 -port $VMPort $installKdumpScript -runAsSudo
+        RemoteCopy -download -downloadFrom $Ipv4 -files $installKdumpLog `
+                   -downloadTo $LogDir -port $VMPort -username $VMUserName `
+                   -password $VMPassword
+
+        Stop-VM -ComputerName $hvServer -Name $vmName -Force -Confirm:$false
+        Wait-VMState -VMName $VMName -HvServer $HvServer -VMState "Off"
+        Start-VM -ComputerName $hvServer -Name $vmName
+        Wait-VMState -VMName $VMName -HvServer $HvServer -VMState "Running"
+        Wait-VMHeartbeatOK -VMName $VMName -HvServer $HvServer
+    }
+
+    LogMsg "Enable sysrq on VM"
+    $enableSysrqScript = "echo '${VMPassword}' | sudo -S -s eval `"export HOME=``pwd``;sysctl -w kernel.sysrq=1`""
+    RunLinuxCmd -username $VMUserName -password $VMPassword `
+                -ip $Ipv4 -port $VMPort $enableSysrqScript
+
+    LogMsg "Trigger kernel panic on the VM"
+    $prePanicTime = [DateTime]::Now
+    $triggerSysrqScript = "echo '${VMPassword}' | sudo -S -s eval `"export HOME=``pwd``;echo 'echo c > /proc/sysrq-trigger' | at now + 1 minutes`""
+    RunLinuxCmd -username $VMUserName -password $VMPassword `
+                -ip $Ipv4 -port $VMPort $triggerSysrqScript
+
+    LogMsg "Check host event log for the 18590 event from the VM"
+    Start-Sleep -Seconds 60
+    $testPassed = Get-VMPanicEvent -VMName $VMName -HvServer $HvServer `
+                                   -StartTime $prePanicTime
+    if (-not $testPassed) {
+        LogErr "Error: Event 18590 was not logged by VM ${vmName}"
+        LogErr "Make sure KDump status is stopped on the VM"
+        return "FAIL"
+    } else {
+        LogMsg "VM ${vmName} successfully logged an 18590 event"
+    }
+
+    LogMsg "Stop / Start VM to check the sanity"
+    Stop-VM -ComputerName $hvServer -Name $vmName -Force -Confirm:$false
+    Wait-VMState -VMName $VMName -HvServer $HvServer -VMState "Off"
+    Start-VM -ComputerName $hvServer -Name $vmName
+    Wait-VMState -VMName $VMName -HvServer $HvServer -VMState "Running"
+    Wait-VMHeartbeatOK -VMName $VMName -HvServer $HvServer
+
+    return "PASS"
+}
+
+try {
+    Check-VMBusPanicEvent -VMName $AllVMData.RoleName `
+        -HvServer $xmlConfig.config.Hyperv.Hosts.ChildNodes[0].ServerName `
+        -Ipv4 $AllVMData.PublicIP -VMPort $AllVMData.SSHPort `
+        -VMUserName $user -VMPassword $password `
+        -TestParams (ConvertFrom-StringData $TestParams.Replace(";","`n")) `
+        -LogDir $LogDir
+    
+} catch {
+    LogErr "Error triggering VMBus panic event with error message: $_"
+    return "FAIL"
+}

--- a/XML/TestCases/FunctionalTests.xml
+++ b/XML/TestCases/FunctionalTests.xml
@@ -710,4 +710,48 @@
         <Area>NET</Area>
         <Tags>net</Tags>
     </test>
+    <test>
+        <testName>VMBUS_VERIFY_PROTOCOL_VERSION</testName>
+        <testScript>verify_vmbus_protocol_version.sh</testScript>
+        <files>.\Testscripts\Linux\verify_vmbus_protocol_version.sh,.\Testscripts\Linux\utils.sh</files>
+        <setupType>SingleVM</setupType>
+        <Platform>HyperV</Platform>
+        <Category>Functional</Category>
+        <Area>LIS</Area>
+        <Tags>lis,vmbus</Tags>
+    </test>
+    <test>
+        <testName>VMBUS_VERIFY_INTERRUPTS</testName>
+        <testScript>verify_vmbus_interrupts.sh</testScript>
+        <files>.\Testscripts\Linux\verify_vmbus_interrupts.sh,.\Testscripts\Linux\utils.sh</files>
+        <setupType>VMBUS</setupType>
+        <Platform>HyperV</Platform>
+        <Category>Functional</Category>
+        <Area>LIS</Area>
+        <Tags>lis,vmbus</Tags>
+    </test>
+    <test>
+        <testName>VMBUS_PANIC_NOTIFIER</testName>
+        <testScript>Check-VMBUSPanicEvent.ps1</testScript>
+        <files>.\Testscripts\Linux\utils.sh</files>
+        <setupType>SingleVM</setupType>
+        <Platform>HyperV</Platform>
+        <Category>Functional</Category>
+        <Area>LIS</Area>
+        <Tags>lis,vmbus</Tags>
+    </test>
+    <test>
+        <testName>VMBUS_PANIC_NOTIFIER_KDUMP</testName>
+        <testScript>Check-VMBUSPanicEvent.ps1</testScript>
+        <files>.\Testscripts\Linux\KDUMP-Config.sh,.\Testscripts\Linux\utils.sh</files>
+        <TestParameters>
+            <param>ENABLE_KDUMP=true</param>
+            <param>crashkernel=384M@128M</param>
+        </TestParameters>
+        <setupType>SingleVM</setupType>
+        <Platform>HyperV</Platform>
+        <Category>Functional</Category>
+        <Area>LIS</Area>
+        <Tags>lis,vmbus</Tags>
+    </test>
 </TestCases>

--- a/XML/VMConfigurations/FunctionalTestsConfigurations.xml
+++ b/XML/VMConfigurations/FunctionalTestsConfigurations.xml
@@ -440,4 +440,22 @@
             </VirtualMachine>
         </ResourceGroup>
     </RDMA16VMs>
+    <VMBUS>
+        <isDeployed>NO</isDeployed>
+        <ResourceGroup>
+            <VirtualMachine>
+                <state></state>
+                <InstanceSize>Standard_A3</InstanceSize>
+                <ARMInstanceSize>Standard_A3</ARMInstanceSize>
+                <RoleName></RoleName>
+                <EndPoints>
+                    <Name>SSH</Name>
+                    <Protocol>tcp</Protocol>
+                    <LocalPort>22</LocalPort>
+                    <PublicPort>22</PublicPort>
+                </EndPoints>
+                <DataDisk></DataDisk>
+            </VirtualMachine>
+        </ResourceGroup>
+    </VMBUS>
 </TestSetup>


### PR DESCRIPTION
Added 4 VMBUS tests:
    1. VMBUS_VERIFY_PROTOCOL_VERSION (checks vmbus info appears in dmesg)
    2. VMBUS_VERIFY_INTERRUPTS (checks vmbus interrupts for each cpu)
    3. VMBUS_PANIC_NOTIFIER (checks panic event sent to hypervisor)
    4. VMBUS_PANIC_NOTIFIER_KDUMP (checks panic event sent to hypervisor when kdump is enabled)

tested on centos 7.5 and ubuntu bionic.
VHD under test F:\Hyper-V\VHDs\lisav2\Centos_7.5_x64.vhd
ARM Image under test  :  :  : 
Total Executed TestCases        2 (       2 Pass,        0 Fail,        0 Abort)
Total Execution Time(dd:hh:mm) 0:0:8
XML file: TestConfiguration

#Sr. Test Name : Test Result : Test Duration (in minutes)
----------------------------------------------------
1. VMBUS_PANIC_NOTIFIER : PASS : 3.73
2. VMBUS_PANIC_NOTIFIER_KDUMP : PASS : 4.95

VHD under test F:\Hyper-V\VHDs\lisav2\ubuntu_18.04.vhd
ARM Image under test  :  :  : 
Total Executed TestCases        1 (       1 Pass,        0 Fail,        0 Abort)
Total Execution Time(dd:hh:mm) 0:0:7
XML file: TestConfiguration

#Sr. Test Name : Test Result : Test Duration (in minutes)
----------------------------------------------------
1. VMBUS_PANIC_NOTIFIER_KDUMP : PASS : 7.03
