### PR TITLE
Appending BUILD NUMBER/NAME to captured VHD

### DIFF
--- a/Testscripts/Windows/CAPTURE-VHD-BEFORE-TEST.ps1
+++ b/Testscripts/Windows/CAPTURE-VHD-BEFORE-TEST.ps1
@@ -24,12 +24,19 @@ function Main {
         LogMsg "Shutting down VM.."
         $stopVM = Stop-AzureRmVM -Name $captureVMData.RoleName -ResourceGroupName $captureVMData.ResourceGroupName -Force -Verbose
         LogMsg "Shutdown successful."
+        $Append = $Distro
+        if ($env:BUILD_NAME){
+            $Append += "-$env:BUILD_NAME"
+        }
+        if ($env:BUILD_NUMBER){
+            $Append += "-$env:BUILD_NUMBER"
+        }
         #Copy the OS VHD with different name.
         if ($ARMImage) {
-            $newVHDName = "EOSG-AUTOBUILT-$($ARMImage.Publisher)-$($ARMImage.Offer)-$($ARMImage.Sku)-$($ARMImage.Version)-$Distro"
+            $newVHDName = "EOSG-AUTOBUILT-$($ARMImage.Publisher)-$($ARMImage.Offer)-$($ARMImage.Sku)-$($ARMImage.Version)-$Append"
         }
         if ($OsVHD) {
-            $newVHDName = "EOSG-AUTOBUILT-$($OsVHD.Replace('.vhd',''))-$Distro"
+            $newVHDName = "EOSG-AUTOBUILT-$($OsVHD.Replace('.vhd',''))-$Append"
         }
         $newVHDName = "$newVHDName.vhd"
         LogMsg "Sleeping 30 seconds..."


### PR DESCRIPTION
This helps to isolate the capture VHDs based on build numbers and build names.

Note: This change is required for migration to LISAv2 for existing pipelines.