### PR TITLE
Move RGIdentifier to required for both hyperv & azure

### DIFF
--- a/RunTests.ps1
+++ b/RunTests.ps1
@@ -41,7 +41,6 @@ Param(
 
 	#[Required] for Azure.
 	[string] $TestLocation="",
-	[string] $RGIdentifier = "",
 	[string] $ARMImageName = "",
 	[string] $StorageAccount="",
 
@@ -52,6 +51,7 @@ Param(
 	[string] $DestinationOsVHDPath="",
 
 	#[Required] Common for HyperV and Azure.
+	[string] $RGIdentifier = "",
 	[string] $OsVHD = "",   #... [Azure: Required only if -ARMImageName is not provided.]
 							#... [HyperV: Mandatory]
 	[string] $TestCategory = "",
@@ -464,3 +464,4 @@ try {
 
 	exit $ExitCode
 }
+


### PR DESCRIPTION
As RGIdentifier is required for both hyperv & azure move it to proper place to avoid confusion for new users.