### PR TITLE
hyper-v: Increase retry count on getting IP

### DIFF
--- a/Libraries/HyperV.psm1
+++ b/Libraries/HyperV.psm1
@@ -613,7 +613,7 @@ Function GetAllHyperVDeployementData($HyperVGroupNames,$RetryCount = 100)
             $VM = Get-VM -Name $property.Name -ComputerName $ComputerName
             $VMNicProperties =  Get-VMNetworkAdapter -ComputerName $ComputerName -VMName $property.Name
 
-            $RetryCount = 20
+            $RetryCount = 50
             $CurrentRetryAttempt=0
             $QuickVMNode = CreateQuickVMNode
             do


### PR DESCRIPTION
On VM creation 20 retries is too low (20*5 seconds). Increasing to 50
retries because sometimes a VM will take longer to boot