### PR TITLE
enableRoot: Do sync to fix #244

### DIFF
--- a/Testscripts/Linux/enableRoot.sh
+++ b/Testscripts/Linux/enableRoot.sh
@@ -38,4 +38,7 @@ if [ $sshdServiceStatus == 0 ]; then
 else
     echo "SSHD_RESTART_FAIL"
 fi
+
+sync
+
 exit 0


### PR DESCRIPTION
This fixes an issue where the ssh daemon config file could remain blank after the changes.
Adding a sync command to flush all the changes to disk.