### PR TITLE
Fixed a breaking issue introduced in PR #238

### DIFF
--- a/AzureTestSuite.ps1
+++ b/AzureTestSuite.ps1
@@ -108,12 +108,12 @@ Function RunTestsOnCycle ($cycleName , $xmlConfig, $Distro, $TestIterations ) {
 		$ExecuteSetupForEachTest = $true
 	} elseif ($testPlatform -eq "Hyperv") {
 		$ExecuteSetupForEachTest = $false
-		$VmSetup = @()
-		foreach ($test in $currentCycleData.test) {
-			$currentTestData = GetCurrentTestData -xmlConfig $xmlConfig -testName $test.Name
-			$VmSetup += $currentTestData.setupType	
-		}
 	}
+	$VmSetup = @()
+	foreach ($test in $currentCycleData.test) {
+		$currentTestData = GetCurrentTestData -xmlConfig $xmlConfig -testName $test.Name
+		$VmSetup += $currentTestData.setupType	
+	}	
 
 	$testCount = $currentCycleData.test.Length
 	$testIndex = 0


### PR DESCRIPTION
Variable VmSetup is only defined for HyperV but it is used irrespective of Test Platform which is causing referring to null array when running Azure Test cases.