### PR TITLE
kernel_install: Added support for multiple kernel install files

### DIFF
--- a/Libraries/CommonFunctions.psm1
+++ b/Libraries/CommonFunctions.psm1
@@ -319,20 +319,30 @@ function InstallCustomKernel ($CustomKernel, $allVMData, [switch]$RestartAfterUp
 			$jobCount = 0
 			$kernelSuccess = 0
 			$packageInstallJobs = @()
+			$CustomKernelLabel = $CustomKernel
 			foreach ( $vmData in $allVMData )
 			{
 				RemoteCopy -uploadTo $vmData.PublicIP -port $vmData.SSHPort -files ".\Testscripts\Linux\$scriptName,.\Testscripts\Linux\DetectLinuxDistro.sh" -username $user -password $password -upload
-				if ( $CustomKernel.StartsWith("localfile:"))
-				{
+				if ( $CustomKernel.StartsWith("localfile:")) {
 					$customKernelFilePath = $CustomKernel.Replace('localfile:','')
-					RemoteCopy -uploadTo $vmData.PublicIP -port $vmData.SSHPort -files ".\$customKernelFilePath" -username $user -password $password -upload
+					$customKernelFilePath = (Resolve-Path $customKernelFilePath).Path
+					if ($customKernelFilePath -and (Test-Path $customKernelFilePath)) {
+						RemoteCopy -uploadTo $vmData.PublicIP -port $vmData.SSHPort -files $customKernelFilePath `
+							-username $user -password $password -upload
+					} else {
+						LogErr "Failed to find kernel file ${customKernelFilePath}"
+						return $false
+					}
+					$CustomKernelLabel = "localfile:{0}" -f @((Split-Path -Leaf $CustomKernel.Replace('localfile:','')))
 				}
 				RemoteCopy -uploadTo $vmData.PublicIP -port $vmData.SSHPort -files ".\Testscripts\Linux\$scriptName,.\Testscripts\Linux\DetectLinuxDistro.sh" -username $user -password $password -upload
 
 				$Null = RunLinuxCmd -ip $vmData.PublicIP -port $vmData.SSHPort -username $user -password $password -command "chmod +x *.sh" -runAsSudo
 				$currentKernelVersion = RunLinuxCmd -ip $vmData.PublicIP -port $vmData.SSHPort -username $user -password $password -command "uname -r"
 				LogMsg "Executing $scriptName ..."
-				$jobID = RunLinuxCmd -ip $vmData.PublicIP -port $vmData.SSHPort -username $user -password $password -command "/home/$user/$scriptName -CustomKernel $CustomKernel -logFolder /home/$user" -RunInBackground -runAsSudo
+				$jobID = RunLinuxCmd -ip $vmData.PublicIP -port $vmData.SSHPort -username $user `
+					-password $password -command "/home/$user/$scriptName -CustomKernel '$CustomKernelLabel' -logFolder /home/$user" `
+					-RunInBackground -runAsSudo
 				$packageInstallObj = New-Object PSObject
 				Add-member -InputObject $packageInstallObj -MemberType NoteProperty -Name ID -Value $jobID
 				Add-member -InputObject $packageInstallObj -MemberType NoteProperty -Name RoleName -Value $vmData.RoleName


### PR DESCRIPTION
This patch allows multiple kernel files to be installed -- for example hyperv daemons, image or debug kernel.

Example Run-Lisav2 argument:
-CustomKernel "localfile:C:\debfolders\*.deb". Now lisav2 will make sure it uploads all the files and installs them.
Works with -CustomKernel "localfile:C:\debfolders\*.rpm" too.

