### PR TITLE
utils.sh: Set LIS_HOME to location where files copied to

### DIFF
--- a/Testscripts/Linux/utils.sh
+++ b/Testscripts/Linux/utils.sh
@@ -27,7 +27,7 @@ IFS=$' \t\n'
 # All vars are first defined here
 
 # Directory containing all files pushed by LIS framework
-declare LIS_HOME="$HOME"
+declare LIS_HOME=$(pwd)
 
 # LIS state file used by powershell to get the test's state
 declare __LIS_STATE_FILE="$LIS_HOME/state.txt"


### PR DESCRIPTION
I'm running the tests with non root user ( a sudo user). 
In this case I see that test files are copied to /home/$username not to /root
However when scripts are run on guest as sudo user the $HOME will be /root and files are not there in /root