### PR TITLE
Azure: Added support to ephemeral OS Disk (Preview)

### DIFF
--- a/Libraries/Azure.psm1
+++ b/Libraries/Azure.psm1
@@ -791,9 +791,12 @@ Function GenerateAzureDeployJSONFile ($RGName, $osImage, $osVHD, $RGXMLData, $Lo
 #Random Data
 $RGrandomWord = ([System.IO.Path]::GetRandomFileName() -replace '[^a-z]')
 $RGRandomNumber = Get-Random -Minimum 11111 -Maximum 99999
-if ( $CurrentTestData.AdditionalHWConfig.DiskType -eq "Managed" )
+if ( $CurrentTestData.AdditionalHWConfig.DiskType -eq "Managed" -or $UseManagedDisks )
 {
-    $UseManageDiskForCurrentTest = $true
+    if ( $CurrentTestData.AdditionalHWConfig.DiskType -eq "Managed" )
+    {
+        $UseManageDiskForCurrentTest = $true
+    }
     $DiskType = "Managed"
 }
 else
@@ -2024,10 +2027,9 @@ foreach ( $newVM in $RGXMLData.VirtualMachine)
                         }
                         else
                         {
-                            Add-Content -Value "$($indents[6])^caching^: ^ReadWrite^" -Path $jsonFile
+                            Add-Content -Value "$($indents[6])^caching^: ^ReadWrite^," -Path $jsonFile
                         }                            
                             Add-Content -Value "$($indents[6])^createOption^: ^FromImage^" -Path $jsonFile
-                            LogMsg "Added $DiskType OS disk : $vmName-OSDisk"
                         }
                         else 
                         {
@@ -2041,6 +2043,7 @@ foreach ( $newVM in $RGXMLData.VirtualMachine)
                         }
                     }
                     Add-Content -Value "$($indents[5])}," -Path $jsonFile
+                    LogMsg "Added $DiskType OS disk : $vmName-OSDisk"
                     $dataDiskAdded = $false
                     Add-Content -Value "$($indents[5])^dataDisks^ : " -Path $jsonFile
                     Add-Content -Value "$($indents[5])[" -Path $jsonFile

--- a/XML/TestCases/SmokeTests.xml
+++ b/XML/TestCases/SmokeTests.xml
@@ -22,7 +22,7 @@
         <Platform>Azure</Platform>
         <Category>Smoke</Category>
         <Area>default</Area>
-        <Tags>bvt,disk</Tags>
+        <Tags>ephemeral_os_disk</Tags>
     </test>        
     <test>
         <TestName>VERIFY-DEPLOYMENT-PROVISION-SRIOV</TestName>

--- a/XML/TestCases/SmokeTests.xml
+++ b/XML/TestCases/SmokeTests.xml
@@ -10,6 +10,21 @@
         <Tags>bvt</Tags>
     </test>
     <test>
+        <TestName>VERIFY-DEPLOYMENT-PROVISION-EPHEMERAL-MANAGED-DISK</TestName>
+        <testScript>BVT-VERIFY-DEPLOYMENT-PROVISION.ps1</testScript>
+        <files></files>
+        <setupType>SingleVM</setupType>
+        <OverrideVMSize>Standard_DS1_v2</OverrideVMSize>
+        <AdditionalHWConfig>
+            <DiskType>Managed</DiskType>
+            <OSDiskType>Ephemeral</OSDiskType>
+        </AdditionalHWConfig>        
+        <Platform>Azure</Platform>
+        <Category>Smoke</Category>
+        <Area>default</Area>
+        <Tags>bvt,disk</Tags>
+    </test>        
+    <test>
         <TestName>VERIFY-DEPLOYMENT-PROVISION-SRIOV</TestName>
         <testScript>BVT-VERIFY-DEPLOYMENT-PROVISION.ps1</testScript>
         <files></files>


### PR DESCRIPTION
Now, you can deploy VMs with ephemeral OS disk using following xml tag :
```
<AdditionalHWConfig>
  <DiskType>Managed</DiskType>
  <OSDiskType>Ephemeral</OSDiskType>
</AdditionalHWConfig>
```
Note, You can not use Unmanaged disk + Ephemeral disk configuration.

Validations needed -
**Using default image (ARMImage)**
- [x] Single VM - Managed OS DIsk - No data disk
- [x] Single VM - Managed OS DIsk - With managed data disks
- [x] Single VM - Managed Ephemeral OS DIsk - No data disk
- [x] Single VM - Managed Ephemeral OS DIsk - With managed data disks

**Using custom VHD (Captured Image)**
- [x] Single VM - Managed OS DIsk - No data disk
- [x] Single VM - Managed OS DIsk - With managed data disks
- [x] Single VM - Managed Ephemeral OS DIsk - No data disk
- [x] Single VM - Managed Ephemeral OS DIsk - With managed data disks