### PR TITLE
Fixed issue in SAS URL file name (Inspect-VHD.ps1)

### DIFF
--- a/JenkinsPipelines/Scripts/InspectVHD.ps1
+++ b/JenkinsPipelines/Scripts/InspectVHD.ps1
@@ -57,6 +57,11 @@ try
         if ( $env:CustomVHDURL )
         {
             $SourceVHDName = "$(Split-Path -Path $env:CustomVHDURL -Leaf)"
+            if ($SourceVHDName -imatch '`?')
+            {
+                $SourceVHDName = $SourceVHDName.Split('?')[0]
+            }
+            $SourceVHDName = Remove-InvalidCharactersFromFileName -FileName $SourceVHDName
             $CurrentVHD = "$LocalFolder\$env:UpstreamBuildNumber-$SourceVHDName"
             $ReceivedVHD = "$CurrentRemoteFolder\$SourceVHDName"
             if (Test-Path $ReceivedVHD)

--- a/Libraries/CommonFunctions.psm1
+++ b/Libraries/CommonFunctions.psm1
@@ -4273,3 +4273,15 @@ function Test-GuestInterface {
     return $True
 }
 
+# This function removes all the invalid characters from given filename.
+# Do not pass file paths (relative or full) to this function.
+# Only file name is supported.
+Function Remove-InvalidCharactersFromFileName 
+{
+    param (
+        [String]$FileName
+	)
+    $WindowsInvalidCharacters = [IO.Path]::GetInvalidFileNameChars() -join ''
+    $Regex = "[{0}]" -f [RegEx]::Escape($WindowsInvalidCharacters)
+    return ($FileName -replace $Regex)
+}


### PR DESCRIPTION
**Fixes the issue of incorrect filename when SAS URL is given for download.**

**For example:** 

**SAS URL:** https://xxxxxxxxxxxxxxxx.blob.core.windows.net/vm-images/SLES15-Azure.x86_64-1.0.99-Build2.24.vhd?sp=r&st=2018-10-18T00:00:00Z&se=2018-10-28T00:00:00Z&spr=https&sv=2017-11-09&sig=xXxXxXxXxXxXxXxXxXxXxXxXxX&sr=b 

**Downloaded filename:**  SLES15-Azure.x86_64-1.0.99-Build2.24.vhd?sp=r&st=2018-10-18T00:00:00Z&se=2018-10-28T00:00:00Z&spr=https&sv=2017-11-09&sig=xXxXxXxXxXxXxXxXxXxXxXxXxX&sr=b'

**Expected filename:**  SLES15-Azure.x86_64-1.0.99-Build2.24.vhd