### PR TITLE
Fixed : LISAv2 was existing if there was issue in parsing HTML email text

### DIFF
--- a/AzureTestSuite.ps1
+++ b/AzureTestSuite.ps1
@@ -214,8 +214,8 @@ Function RunTestsOnCycle ($cycleName , $xmlConfig, $Distro, $TestIterations ) {
 							$tempHtmlText = ($testSummary).Substring(0,((($testSummary).Length)-6))
 						}
 						catch {
-							ThrowException $_
-							$tempHtmlText = "Unable to parse the results. Will be fixed shortly."
+							LogErr "Unable to parse HTML Logs."
+							$tempHtmlText = "Unable to parse the results."
 						}
 						$executionCount += 1
 						$testRunDuration = GetStopWatchElapasedTime $stopWatch "mm"


### PR DESCRIPTION
HTML email text it not used right now (planned for future). Hence this exception can be safely ignored until we work on HTML reports from LISAv2.

```
10/18/2018 22:30:30 : [INFO ] Cleaning up deployed test virtual machines.
10/18/2018 22:30:30 : [INFO ] Checking if ICA-RG-SingleVM-suse-KJXA-636754983852 exists...
10/18/2018 22:30:33 : [INFO ] Cleanup job ID: '968c8702-7594-4077-9c64-0188f9f6e05e' for 'ICA-RG-SingleVM-suse-KJXA-636754983852' started using runbooks.
10/18/2018 22:30:33 : [INFO ] CleanUP Successful for ICA-RG-SingleVM-suse-KJXA-636754983852..
10/18/2018 22:30:33 : [OOPS   ]: You cannot call a method on a null-valued expression.
10/18/2018 22:30:33 : [SOURCE ]: Line 214 in script .\AzureTestSuite.ps1.
10/18/2018 22:30:33 : [OOPS   ]: Calling function - ThrowException
10/18/2018 22:30:33 : [SOURCE ]: Line 42 in script .\Libraries\CommonFunctions.psm1.

```