### PR TITLE
LISAv2: remove parameters 'UpdateGlobalConfigurationFromSecretsFile a…

### DIFF
--- a/Run-LisaV2.ps1
+++ b/Run-LisaV2.ps1
@@ -73,8 +73,8 @@ Param(
 	[switch] $EnableTelemetry,
 
 	#[Optional] Parameters for dynamically updating XML Secret file.
-	[switch] $UpdateGlobalConfigurationFromSecretsFile,
-	[switch] $UpdateXMLStringsFromSecretsFile,
+	[Obsolete("XMLSecretFile presence indicates UpdateGlobalConfigurationFromSecretsFile is true")] [switch] $UpdateGlobalConfigurationFromSecretsFile,
+	[Obsolete("XMLSecretFile presence indicates UpdateXMLStringsFromSecretsFile is true")] [switch] $UpdateXMLStringsFromSecretsFile,
 
 	#[Optional] Parameters for Overriding VM Configuration.
 	[string] $CustomParameters = "",


### PR DESCRIPTION
…nd UpdateXMLStringSecretsFromSecretsFile

These parameters are removed.  If a secret file is provided, we will attempt to use it.  Modified Framework to remove the check for these values.  Also removed from Groovy scripts.