### PR TITLE
lisav2: Don't copy temp files on workspace change

### DIFF
--- a/Run-LisaV2.ps1
+++ b/Run-LisaV2.ps1
@@ -112,7 +112,10 @@ try {
 		$finalWorkingDirectory = "$TempWorkspace\LISAv2\$shortRandomWord$shortRandomNumber"
 		$tmpSource = '\\?\' + "$OriginalWorkingDirectory\*"
 		Write-Output "Copying current workspace to $finalWorkingDirectory"
-		Copy-Item -Path $tmpSource -Destination $finalWorkingDirectory -Recurse -Force | Out-Null
+		$excludedDirectories = @(".git", ".github", "TestResults",
+			"VHDs_Destination_Path", "*.zip", "report")
+		Copy-Item -Path $tmpSource -Destination $finalWorkingDirectory `
+			-Recurse -Force -Exclude $excludedDirectories | Out-Null
 		Set-Location -Path $finalWorkingDirectory | Out-Null
 		Write-Output "Working directory has been changed to $finalWorkingDirectory"
 		$WorkingDirectory = $finalWorkingDirectory


### PR DESCRIPTION
When lisav2 workspace is changed there is no need to have all the .git files copied plus a lot of temp files from previous runs, which can linearly increase the times for lisav2 to run, without manual cleanup.

PR tested internally and works fine.