### PR TITLE
Removed Obsolete SecretsFile Switches 

### DIFF
--- a/JenkinsPipelines/Run-Boot-Stress-Tests.groovy
+++ b/JenkinsPipelines/Run-Boot-Stress-Tests.groovy
@@ -53,8 +53,6 @@ def ExecuteTest( JenkinsUser, UpstreamBuildNumber, ImageSource, CustomVHD, Custo
                             withCredentials([file(credentialsId: 'Azure_Secrets_File', variable: 'Azure_Secrets_File')]) 
                             {
                                 RunPowershellCommand(".\\Run-LisaV2.ps1" +
-                                " -UpdateGlobalConfigurationFromSecretsFile" +
-                                " -UpdateXMLStringsFromSecretsFile" +
                                 " -RGIdentifier '${JenkinsUser}'" +
                                 " -ExitWithZero" +
                                 FinalImageSource +                                    
@@ -99,8 +97,6 @@ def ExecuteTest( JenkinsUser, UpstreamBuildNumber, ImageSource, CustomVHD, Custo
                             withCredentials([file(credentialsId: 'Azure_Secrets_File', variable: 'Azure_Secrets_File')]) 
                             {
                                 RunPowershellCommand(".\\Run-LisaV2.ps1" +
-                                " -UpdateGlobalConfigurationFromSecretsFile" +
-                                " -UpdateXMLStringsFromSecretsFile" +                                
                                 " -RGIdentifier '${JenkinsUser}'" +                                    
                                 " -ExitWithZero" +
                                 FinalImageSource +                                    

--- a/JenkinsPipelines/Run-Linux-Tests.groovy
+++ b/JenkinsPipelines/Run-Linux-Tests.groovy
@@ -86,8 +86,6 @@ def ExecuteTest( JenkinsUser, UpstreamBuildNumber, ImageSource, CustomVHD, Custo
                                         withCredentials([file(credentialsId: 'Azure_Secrets_File', variable: 'Azure_Secrets_File')]) 
                                         {
                                             RunPowershellCommand(".\\Run-LisaV2.ps1" +
-                                            " -UpdateGlobalConfigurationFromSecretsFile" +
-                                            " -UpdateXMLStringsFromSecretsFile" +                                              
                                             " -ExitWithZero" +
                                             " -XMLSecretFile '${Azure_Secrets_File}'" +
                                             " -TestLocation '${TestRegion}'" +
@@ -145,8 +143,6 @@ def ExecuteTest( JenkinsUser, UpstreamBuildNumber, ImageSource, CustomVHD, Custo
                                         withCredentials([file(credentialsId: 'Azure_Secrets_File', variable: 'Azure_Secrets_File')]) 
                                         {
                                             RunPowershellCommand(".\\Run-LisaV2.ps1" +
-                                            " -UpdateGlobalConfigurationFromSecretsFile" +
-                                            " -UpdateXMLStringsFromSecretsFile" +                                            
                                             " -ExitWithZero" +
                                             " -XMLSecretFile '${Azure_Secrets_File}'" +
                                             " -TestLocation '${TestRegion}'" +
@@ -203,8 +199,6 @@ def ExecuteTest( JenkinsUser, UpstreamBuildNumber, ImageSource, CustomVHD, Custo
                                         withCredentials([file(credentialsId: 'Azure_Secrets_File', variable: 'Azure_Secrets_File')]) 
                                         {
                                             RunPowershellCommand(".\\Run-LisaV2.ps1" +
-                                            " -UpdateGlobalConfigurationFromSecretsFile" +
-                                            " -UpdateXMLStringsFromSecretsFile" +                                            
                                             " -ExitWithZero" +
                                             " -XMLSecretFile '${Azure_Secrets_File}'" +
                                             " -TestLocation '${TestRegion}'" +
@@ -261,8 +255,6 @@ def ExecuteTest( JenkinsUser, UpstreamBuildNumber, ImageSource, CustomVHD, Custo
                                         withCredentials([file(credentialsId: 'Azure_Secrets_File', variable: 'Azure_Secrets_File')]) 
                                         {
                                             RunPowershellCommand(".\\Run-LisaV2.ps1" +
-                                            " -UpdateGlobalConfigurationFromSecretsFile" +
-                                            " -UpdateXMLStringsFromSecretsFile" +                                            
                                             " -ExitWithZero" +
                                             " -XMLSecretFile '${Azure_Secrets_File}'" +
                                             " -TestLocation '${TestRegion}'" +
@@ -382,8 +374,6 @@ stage('Capture VHD with Custom Kernel')
                 KernelFile = readFile 'CustomKernel.azure.env'
                 stash includes: KernelFile, name: 'CustomKernelStash'
                 RunPowershellCommand(".\\Run-LisaV2.ps1" +
-                " -UpdateGlobalConfigurationFromSecretsFile" +
-                " -UpdateXMLStringsFromSecretsFile" +                  
                 " -XMLSecretFile '${Azure_Secrets_File}'" +
                 " -TestLocation 'westus2'" +
                 " -RGIdentifier '${JenkinsUser}'" +

--- a/Libraries/Framework.psm1
+++ b/Libraries/Framework.psm1
@@ -134,25 +134,21 @@ Function Add-ReplaceableTestParameters($XmlConfigFilePath)
 
 Function UpdateGlobalConfigurationXML()
 {
-	#Region Update Global Configuration XML file as needed
-	if ($UpdateGlobalConfigurationFromSecretsFile)
+	if ($XMLSecretFile)
 	{
-		if ($XMLSecretFile)
+		if (Test-Path -Path $XMLSecretFile)
 		{
-			if (Test-Path -Path $XMLSecretFile)
-			{
-				LogMsg "Updating .\XML\GlobalConfigurations.xml"
-				.\Utilities\UpdateGlobalConfigurationFromXmlSecrets.ps1 -XmlSecretsFilePath $XMLSecretFile
-			}
-			else 
-			{
-				LogErr "Failed to update .\XML\GlobalConfigurations.xml. '$XMLSecretFile' not found."    
-			}
+			LogMsg "Updating .\XML\GlobalConfigurations.xml"
+			.\Utilities\UpdateGlobalConfigurationFromXmlSecrets.ps1 -XmlSecretsFilePath $XMLSecretFile
 		}
 		else 
 		{
-			LogErr "Failed to update .\XML\GlobalConfigurations.xml. '-XMLSecretFile [FilePath]' not provided."    
+			LogErr "Failed to update .\XML\GlobalConfigurations.xml. Secrets file not found."    
 		}
+	}
+	else 
+	{
+		LogErr "Failed to update .\XML\GlobalConfigurations.xml. '-XMLSecretFile [FilePath]' not provided."    
 	}
 	$RegionStorageMapping = [xml](Get-Content .\XML\RegionAndStorageAccounts.xml)
 	$GlobalConfiguration = [xml](Get-Content .\XML\GlobalConfigurations.xml)
@@ -268,25 +264,21 @@ Function UpdateGlobalConfigurationXML()
 
 Function UpdateXMLStringsFromSecretsFile()
 {
-	#region Replace strings in XML files
-    if ($UpdateXMLStringsFromSecretsFile)
-    {
-        if ($XMLSecretFile)
-        {
-            if (Test-Path -Path $XMLSecretFile)
-            {
-                .\Utilities\UpdateXMLStringsFromXmlSecrets.ps1 -XmlSecretsFilePath $XMLSecretFile
-            }
-            else 
-            {
-                LogErr "Failed to update Strings in .\XML files. '$XMLSecretFile' not found."    
-            }
-        }
-        else 
-        {
-            LogErr "Failed to update Strings in .\XML files. '-XMLSecretFile [FilePath]' not provided."    
-        }
-    }
+	if ($XMLSecretFile)
+	{
+		if (Test-Path -Path $XMLSecretFile)
+		{
+			.\Utilities\UpdateXMLStringsFromXmlSecrets.ps1 -XmlSecretsFilePath $XMLSecretFile
+		}
+		else 
+		{
+			LogErr "Failed to update Strings in .\XML files. '$XMLSecretFile' not found."    
+		}
+	}
+	else 
+	{
+		LogErr "Failed to update Strings in .\XML files. '-XMLSecretFile [FilePath]' not provided."    
+	}
 }
 
 Function CollectTestCases($TestXMLs)

--- a/Run-LisaV2.ps1
+++ b/Run-LisaV2.ps1
@@ -22,8 +22,6 @@
 	.\Run-LisaV2.ps1	-TestPlatform "Azure" -TestLocation "westus2" -RGIdentifier "mylisatest"
 					-ARMImageName "Canonical UbuntuServer 16.04-LTS latest"
 					-XMLSecretFile "C:\MySecrets.xml"
-					-UpdateGlobalConfigurationFromSecretsFile
-					-UpdateXMLStringsFromSecretsFile
 					-TestNames "BVT-VERIFY-DEPLOYMENT-PROVISION"
 
 
@@ -68,13 +66,8 @@ Param(
 	[int]    $TestIterations,
 	[string] $TiPSessionId,
 	[string] $TiPCluster,
-	# Require both UpdateGlobalConfigurationFromSecretsFile and UpdateXMLStringsFromSecretsFile
 	[string] $XMLSecretFile = "",
 	[switch] $EnableTelemetry,
-
-	#[Optional] Parameters for dynamically updating XML Secret file.
-	[Obsolete("XMLSecretFile presence indicates UpdateGlobalConfigurationFromSecretsFile is true")] [switch] $UpdateGlobalConfigurationFromSecretsFile,
-	[Obsolete("XMLSecretFile presence indicates UpdateXMLStringsFromSecretsFile is true")] [switch] $UpdateXMLStringsFromSecretsFile,
 
 	#[Optional] Parameters for Overriding VM Configuration.
 	[string] $CustomParameters = "",


### PR DESCRIPTION
Removed all references to the following two switches:
   -UpdateGlobalConfigurationFromSecretsFile
   -UpdateXMLStringsFromSecretsFile

When the XMLSecrets file is present, we will execute as if these parameters were both true.  This means we will also generate an error if the file is present and the flags were intended to be omitted.  In looking at the groovy execution, we used both flags each time.  This may be different in job definitions.