### PR TITLE
customKernelInstall: Remove hyperv-tools on rhel

### DIFF
--- a/Testscripts/Linux/customKernelInstall.sh
+++ b/Testscripts/Linux/customKernelInstall.sh
@@ -208,7 +208,7 @@ InstallKernel()
 
                     LogMsg "Removing packages that do not allow the kernel to be installed"
                     if [[ "${customKernelFilesUnExpanded}" == *'*.rpm'* ]]; then
-                        yum remove -y hypervvssd hypervkvpd hypervfcopyd hyperv-daemons
+                        yum remove -y hypervvssd hypervkvpd hypervfcopyd hyperv-daemons hyperv-tools
                     fi
 
                     LogMsg "Installing ${customKernelFilesUnExpanded}"


### PR DESCRIPTION
hyperv-tools contains the lsvmbus tool, removing package so we can install the new version