### PR TITLE
Revert "azure: ARMImageName param can be empty when OSVhd is set"

### DIFF
--- a/Libraries/CommonFunctions.psm1
+++ b/Libraries/CommonFunctions.psm1
@@ -353,7 +353,6 @@ function InstallCustomKernel ($CustomKernel, $allVMData, [switch]$RestartAfterUp
 				#endregion
 			}
 			$packageInstallJobsRunning = $true
-			$kernelMatchSuccess = "CUSTOM_KERNEL_SUCCESS"
 			while ($packageInstallJobsRunning)
 			{
 				$packageInstallJobsRunning = $false
@@ -364,16 +363,13 @@ function InstallCustomKernel ($CustomKernel, $allVMData, [switch]$RestartAfterUp
 						$currentStatus = RunLinuxCmd -ip $job.PublicIP -port $job.SSHPort -username $user -password $password -command "tail -n 1 build-CustomKernel.txt"
 						LogMsg "Package Installation Status for $($job.RoleName) : $currentStatus"
 						$packageInstallJobsRunning = $true
-						if ($currentStatus -imatch $kernelMatchSuccess) {
-							Stop-Job -Id $job.ID -Confirm:$false -ErrorAction SilentlyContinue
-						}
 					}
 					else
 					{
 						if ( !(Test-Path -Path "$LogDir\$($job.RoleName)-build-CustomKernel.txt" ) )
 						{
 							RemoteCopy -download -downloadFrom $job.PublicIP -port $job.SSHPort -files "build-CustomKernel.txt" -username $user -password $password -downloadTo $LogDir
-							if ( ( Get-Content "$LogDir\build-CustomKernel.txt" ) -imatch $kernelMatchSuccess )
+							if ( ( Get-Content "$LogDir\build-CustomKernel.txt" ) -imatch "CUSTOM_KERNEL_SUCCESS" )
 							{
 								$kernelSuccess += 1
 							}
@@ -383,7 +379,7 @@ function InstallCustomKernel ($CustomKernel, $allVMData, [switch]$RestartAfterUp
 				}
 				if ( $packageInstallJobsRunning )
 				{
-					WaitFor -seconds 5
+					WaitFor -seconds 10
 				}
 			}
 			if ( $kernelSuccess -eq $jobCount )

--- a/Libraries/Framework.psm1
+++ b/Libraries/Framework.psm1
@@ -30,7 +30,7 @@ function Validate-AzureParameters {
         $parameterErrors += "-ARMImageName '<Publisher> <Offer> <Sku> <Version>', or -OsVHD <'VHD_Name.vhd'> is required."
     }
 
-    if ($ARMImageName -and ($ARMImageName.Trim().Split(" ").Count -ne 4)) {
+    if (($ARMImageName.Trim().Split(" ").Count -ne 4) -and ($ARMImageName -ne "")) {
         $parameterErrors += ("Invalid value for the provided ARMImageName parameter: <'${ARMImageName}'>." + `
                              "The ARM image should be in the format: '<Publisher> <Offer> <Sku> <Version>'.")
     }


### PR DESCRIPTION
Reverts LIS/LISAv2#349
@juhlee-microsoft I have found that there is one more commit that got merged which wasn t tested, i ll revert it for now