### PR TITLE
azuremodules.py: Fix issue in distro detection

### DIFF
--- a/Testscripts/Linux/azuremodules.py
+++ b/Testscripts/Linux/azuremodules.py
@@ -96,9 +96,8 @@ def DetectDistro():
     version = 'unknown'
 
     RunLog.info("Detecting Distro ")
-    if os.path.isfile("/etc/*-release"):
-        output = Run("cat /etc/*-release")
-    elif os.path.isfile("/usr/lib/os-release"):
+    output = Run("cat /etc/*-release")
+    if output == "" and os.path.isfile("/usr/lib/os-release"):
         output = Run("cat /usr/lib/os-release")
     outputlist = re.split("\n", output)
 


### PR DESCRIPTION
 os.path.isfile can't run against file name with wildcard
Run against clearos and centos, both are pass