### PR TITLE
framework: $OsVHD/$ARMImageName parameter bugfix

### DIFF
--- a/Libraries/Framework-Azure.psm1
+++ b/Libraries/Framework-Azure.psm1
@@ -30,16 +30,20 @@ function Validate-AzureParameters {
         $parameterErrors += "-ARMImageName '<Publisher> <Offer> <Sku> <Version>', or -OsVHD <'VHD_Name.vhd'> is required."
     }
 
-    if (($ARMImageName.Trim().Split(" ").Count -ne 4) -and ($ARMImageName -ne "")) {
-        $parameterErrors += ("Invalid value for the provided ARMImageName parameter: <'${ARMImageName}'>." + `
-                             "The ARM image should be in the format: '<Publisher> <Offer> <Sku> <Version>'.")
+    if (!$OsVHD) {
+        if (($ARMImageName.Trim().Split(" ").Count -ne 4) -and ($ARMImageName -ne "")) {
+            $parameterErrors += ("Invalid value for the provided ARMImageName parameter: <'${ARMImageName}'>." + `
+                                 "The ARM image should be in the format: '<Publisher> <Offer> <Sku> <Version>'.")
+        }   
+    }
+    
+    if (!$ARMImageName) {
+        if ($OsVHD -and [System.IO.Path]::GetExtension($OsVHD) -ne ".vhd") {
+            $parameterErrors += "-OsVHD $OsVHD does not have .vhd extension required by Platform Azure."
+        }    
     }
 
-    if ($OsVHD -and [System.IO.Path]::GetExtension($OsVHD) -ne ".vhd") {
-        $parameterErrors += "-OsVHD $OsVHD does not have .vhd extension required by Platform Azure."
-    }
-
-    if ( !$TestLocation) {
+    if (!$TestLocation) {
         $parameterErrors += "-TestLocation <AzureRegion> is required."
     }
 


### PR DESCRIPTION
This is fixing an issue on Azure where lisav2 would fail if -OsVHD param was given. The framework is working with either OsVHD or ARMImageName param. But in Framework-Azure.psm1 no check was made to see what parameter is available and what parameter isn't. This is adding an extra check before manipulating each of these params.
Even though the error message doesn't explicitly throw a message regarding the params issue, L33 which is pointed in Framework-Azure.psm1 is the one that triggers this.

## Before this fix
11/08/2018 13:23:58 : [INFO ] Created LogDir: .\TestResults\2018-08-11-05-23-58-0449
11/08/2018 13:23:58 : [INFO ] -VMGeneration not specified. Using default VMGeneration = 1
.\Run-LisaV2.ps1 -TestLocation 'westus2' -RGIdentifier 'adsuhoTest' -TestPlatform 'Azure' -TestNames
"BVT-VERIFY-DEPLOYMENT-PROVISION" -OsVHD '**185-sles-15-azure-kern-test-v20181106.vhd**' : WebClient failed to download required tools
from blob Storage Location. Those files should be placed in Tools folder before next execution.
    + CategoryInfo          : NotSpecified: (:) [Write-Error], WriteErrorException
    + FullyQualifiedErrorId : Microsoft.PowerShell.Commands.WriteErrorException

11/08/2018 13:23:58 : [INFO ] EXCEPTION : You cannot call a method on a null-valued expression.
11/08/2018 13:23:58 : [INFO ] Source : Line 33 in script .\Libraries\Framework-Azure.psm1.
11/08/2018 13:23:58 : [INFO ] LISAv2 exits with code: 1

## After this fix
VHD under test **185-sles-15-azure-kern-test-v20181106.vhd**
ARM Image under test  :  :  :
Total Executed TestCases        1 (       1 Pass,        0 Fail,        0 Abort)
Total Execution Time(dd:hh:mm) 0:0:6
XML file: TestConfiguration

#Sr. Test Name : Test Result : Test Duration (in minutes)
----------------------------------------------------
1. BVT-VERIFY-DEPLOYMENT-PROVISION : PASS : 6.9
        FirstBoot : PASS
        FirstBoot : Call Trace Verification : PASS
        Reboot : PASS
        Reboot : Call Trace Verification : PASS