### PR TITLE
framework: Multiple test areas at runtime

### DIFF
--- a/Libraries/Framework-Azure.psm1
+++ b/Libraries/Framework-Azure.psm1
@@ -347,7 +347,8 @@ Function CollectTestCases($TestXMLs)
             {
                 foreach ( $test in $currentTests.test )
                 {
-                    if ( ($test.Platform.Split(",").Contains($TestPlatform) ) -and $($TestCategory -eq $test.Category) -and $($TestArea -eq $test.Area) )
+                    if (($test.Platform.Split(",").Contains($TestPlatform) ) -and $($TestCategory -eq $test.Category) `
+                        -and $($TestArea.Split(",").Contains($test.Area)))
                     {
                         LogMsg "Collected $($test.TestName)"
                         $allTests += $test


### PR DESCRIPTION
Right now lisav2 doesn't accept multiple test areas at runtime (e.g. we can't run KVP,FCOPY,etc at once). We can only run a full category or a single area. This commit is giving some flexibility since we can control better what tests we want to run.
**This is not changing previous runtime parameters/behavior (e.g. one area testing will work as well), just adds a small improvement.** 

## With this change
PS C:\Users\v-adsuho\Documents\lisav2> .\Run-LisaV2.ps1 -TestPlatform 'Azure' -ARMImageName 'Canonical UbuntuServer 14.04.5-LTS latest
' -RGIdentifier 'adsuhoTest' -TestLocation 'westus2' -TestCategory 'Functional' **-TestArea 'KVP,CORE,SRIOV'**
11/08/2018 13:49:21 : [INFO ] Created LogDir: .\TestResults\2018-08-11-05-49-21-2079
11/08/2018 13:49:21 : [INFO ] Test parameters have been validated successfully. Continue running the test.
11/08/2018 13:49:21 : [INFO ] Validating XML Files from C:\Users\v-adsuho\Documents\lisav2 folder recursively...
11/08/2018 13:49:21 : [INFO ] Collected VERIFY-SRIOV-LSPCI
11/08/2018 13:49:21 : [INFO ] Collected VERIFY-IFUP-NICS-SRIOV
11/08/2018 13:49:21 : [INFO ] Collected VERIFY-ENABLE-DISABLE-SRIOV-ON-EXISTING-VM
11/08/2018 13:49:21 : [INFO ] Collected SRIOV-VERIFY-VF-BASIC-CONNECTION
11/08/2018 13:49:21 : [INFO ] Collected SRIOV-VERIFY-VF-BASIC-CONNECTION-MAX-VCPU
11/08/2018 13:49:21 : [INFO ] Collected SRIOV-VERIFY-VF-MULTIPLE-CONNECTION
11/08/2018 13:49:21 : [INFO ] Collected SRIOV-VERIFY-VF-MAX-CONNECTION
11/08/2018 13:49:21 : [INFO ] Collected SRIOV-VERIFY-VF-MAX-CONNECTION-MAX-VCPU
11/08/2018 13:49:21 : [INFO ] Collected SRIOV-IPERF-STRESS
11/08/2018 13:49:21 : [INFO ] Collected SRIOV-DISABLEVF-ON-GUEST
11/08/2018 13:49:21 : [INFO ] Collected SRIOV-RELOAD-MODULE
11/08/2018 13:49:21 : [INFO ] Collected KVP-BASIC-CHECKS
11/08/2018 13:49:21 : [INFO ] Collected CORE-INITRD-MODULES-CHECK
11/08/2018 13:49:21 : [INFO ] Collected CORE-CPU-VERIFY-ONLINE
11/08/2018 13:49:21 : [INFO ] Collected CORE-VERIFY-LIS-MODULES-VERSION

## Without this change
C:\Users\v-adsuho\Documents\lisav2> .\Run-LisaV2.ps1 -TestPlatform 'Azure' -ARMImageName 'Canonical UbuntuServer 14.04.5-LTS latest
' -RGIdentifier 'adsuhoTest' -TestLocation 'westus2' -TestCategory 'Functional' **-TestArea 'KVP,CORE,SRIOV'**
11/08/2018 13:51:10 : [INFO ] Created LogDir: .\TestResults\2018-08-11-05-51-10-0191
11/08/2018 13:51:10 : [INFO ] -VMGeneration not specified. Using default VMGeneration = 1
11/08/2018 13:51:10 : [INFO ] Test parameters have been validated successfully. Continue running the test.
11/08/2018 13:51:10 : [INFO ] Validating XML Files from C:\Users\v-adsuho\Documents\lisav2 folder recursively...
11/08/2018 13:51:10 : [INFO ] EXCEPTION : Specified -TestNames or -TestCategory not found
11/08/2018 13:51:10 : [INFO ] Source : Line 214 in script .\Run-LisaV2.ps1.
11/08/2018 13:51:10 : [INFO ] LISAv2 exits with code: 1