### PR TITLE
SR-IOV-Utils.sh: Function fix for SLES15

### DIFF
--- a/Testscripts/Linux/SR-IOV-Utils.sh
+++ b/Testscripts/Linux/SR-IOV-Utils.sh
@@ -73,13 +73,20 @@ VerifyVF()
         exit 1
     fi
 
-    interface=$(ls /sys/class/net/ | grep -v 'eth0\|eth1\|lo' | head -1)
-    ip a | grep $interface
+    if [ -z $VF_IP1 ]; then
+        vf_interface=$(ls /sys/class/net/ | grep -v 'eth0\|eth1\|lo' | head -1)
+    else
+        synthetic_interface=$(ip addr | grep $VF_IP1 | awk '{print $NF}')
+        vf_interface=$(find /sys/devices/* -name "*${synthetic_interface}*" | grep "pci" | sed 's/\// /g' | awk '{print $12}')
+    fi
+
+    ip addr show $vf_interface
     if [ $? -ne 0 ]; then
-        LogErr "VF device, $interface , was not found!"
+        LogErr "VF device, $vf_interface , was not found!"
         SetTestStateFailed
         exit 1
     fi
+
 
     return 0
 }


### PR DESCRIPTION
Fixed VerifyVF function. VF name wasn't properly set in some cases on Azure. Since on Azure we have an IP set before the test starts, we now look for the IP to get the synthetic nic. With the synthethic NIC we can further get the VF .

### Before this fix (guest log)
Thu Nov 08 14:46:18 2018 : Testscript running on suse_15
Thu Nov 08 14:46:18 2018 : Successfully initialized testscript!
Thu Nov 08 11:46:18 2018 : VF device,  , was not found!
Thu Nov 08 11:46:18 2018 : VF device,  , was not found!

**As you can see, the VF name is empty**

### After this fix (guest log)
Thu Nov 08 14:48:56 2018 : Testscript running on suse_15
Thu Nov 08 14:48:56 2018 : Successfully initialized testscript!
Thu Nov 08 14:48:56 2018 : VF is in use
 
(PS log)
11/08/2018 14:49:10 : [INFO ] CURRENT - **PASS    - 1** 11/08/2018 14:49:10 : [INFO ] CURRENT - FAIL    - 0
11/08/2018 14:49:10 : [INFO ] CURRENT - ABORTED - 0

