### PR TITLE
Fixing issue #26 

### DIFF
--- a/Testscripts/Linux/BVT-VERIFY-BOOT-ERROR-WARNINGS.py
+++ b/Testscripts/Linux/BVT-VERIFY-BOOT-ERROR-WARNINGS.py
@@ -2,17 +2,16 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the Apache License.
 from azuremodules import *
-import os
 
 white_list_xml = "ignorable-boot-errors.xml"
+
 
 def RunTest():
     UpdateState("TestRunning")
     RunLog.info("Checking for ERROR and WARNING messages in  kernel boot line.")
-    errors = Run("dmesg | grep -i error")
-    warnings = Run("dmesg | grep -i warning")
-    failures = Run("dmesg | grep -i fail")
-
+    errors = Run("grep -nw '/var/log/syslog' -e 'error' --ignore-case && grep -nw '/var/log/messages' -e 'error' --ignore-case")
+    warnings = Run("grep -nw '/var/log/syslog' -e 'warning' --ignore-case && grep -nw '/var/log/messages' -e 'warning' --ignore-case")
+    failures = Run("grep -nw '/var/log/syslog' -e 'fail' --ignore-case && grep -nw '/var/log/messages' -e 'fail' --ignore-case")
     if (not errors and not warnings and not failures):
         RunLog.error('ERROR/WARNING/FAILURE are not present in kernel boot line.')
         ResultLog.info('PASS')
@@ -29,7 +28,7 @@ def RunTest():
             RunLog.info('Checking ignorable boot ERROR/WARNING/FAILURE messages...')
             for node in xml_root:
                 if (failures and node.tag == "failures"):
-                    failures = RemoveIgnorableMessages(failures, node)                            
+                    failures = RemoveIgnorableMessages(failures, node)
                 if (errors and node.tag == "errors"):
                     errors = RemoveIgnorableMessages(errors, node)
                 if (warnings and node.tag == "warnings"):


### PR DESCRIPTION
Issue #26 : Improve checking of the call traces
Current method: dmesg | grep -i 'call trace'
Proposed method : grep -rnw '/var/log' -e 'call trace' --ignore-case

Before fix :

 ARM Image under test Canonical : UbuntuServer : 18.04-LTS : latest
 Total Executed TestCases         1 (        0 Pass,         1 Fail,         0 Abort)
 Total Execution Time(dd:hh:mm) 0:0:3
 XML file: TestConfiguration
 
 #Sr. Test Name : Test Result : Test Duration (in minutes)
 ----------------------------------------------------
 1. BVT-VERIFY-BOOT-ERROR-WARNINGS : FAIL : 3.42
 Logs : 

11/13/2018 03:07:22 PM : INFO : Checking for ERROR and WARNING messages in  kernel boot line.
11/13/2018 03:07:22 PM : DEBUG : [    4.661236] GPT: Use GNU Parted to correct GPT errors.
[    4.983814] RAS: Correctable Errors collector initialized.

11/13/2018 03:07:22 PM : DEBUG : [   17.906061] random: 7 urandom warning(s) missed due to ratelimiting

11/13/2018 03:07:22 PM : DEBUG : [    0.196613] NMI watchdog: Perf event create on CPU 0 failed with -2
[    0.396015] acpi PNP0A03:00: _OSC failed (AE_NOT_FOUND); disabling ASPM
[    0.400018] acpi PNP0A03:00: fail to add MMCONFIG information, can't access extended PCI configuration space under this bridge.

11/13/2018 03:07:22 PM : INFO : Checking ignorable boot ERROR/WARNING/FAILURE messages...
11/13/2018 03:07:22 PM : INFO : Ignorable ERROR/WARNING/FAILURE message: [    0.196613] NMI watchdog: Perf event create on CPU 0 failed with -2
11/13/2018 03:07:22 PM : INFO : Ignorable ERROR/WARNING/FAILURE message: [    0.396015] acpi PNP0A03:00: _OSC failed (AE_NOT_FOUND); disabling ASPM
11/13/2018 03:07:22 PM : INFO : Ignorable ERROR/WARNING/FAILURE message: [    0.400018] acpi PNP0A03:00: fail to add MMCONFIG information, can't access extended PCI configuration space under this bridge.
11/13/2018 03:07:22 PM : INFO : Ignorable ERROR/WARNING/FAILURE message: [   17.906061] random: 7 urandom warning(s) missed due to ratelimiting
11/13/2018 03:07:22 PM : INFO : ERROR/WARNING/FAILURE are  present in kernel boot line.
11/13/2018 03:07:22 PM : INFO : Errors: [    4.661236] GPT: Use GNU Parted to correct GPT errors.[    4.983814] RAS: Correctable Errors collector initialized.

After fix : 

 ARM Image under test Canonical : UbuntuServer : 18.04-LTS : latest
 Total Executed TestCases         1 (        0 Pass,         1 Fail,         0 Abort)
 Total Execution Time(dd:hh:mm) 0:0:3
 XML file: TestConfiguration
 
 #Sr. Test Name : Test Result : Test Duration (in minutes)
 ----------------------------------------------------
 1. BVT-VERIFY-BOOT-ERROR-WARNINGS : FAIL : 3.61

Logs : 

1/13/2018 03:57:54 PM : INFO : Checking for ERROR and WARNING messages in  kernel boot line.
11/13/2018 03:57:54 PM : DEBUG : 735:Nov 13 15:57:03 ICA-RG-SingleVM-role-0 HV_FCOPY: open /dev/vmbus/hv_fcopy failed; error: 2 No such file or directory
782:Nov 13 15:57:03 ICA-RG-SingleVM-role-0 snapd[1266]: 2018/11/13 15:57:01.998696 helpers.go:119: error trying to compare the snap system key: system-key missing on disk
909:Nov 13 15:57:14 ICA-RG-SingleVM-role-0 systemd-resolved[894]: Server returned error NXDOMAIN, mitigating potential DNS violation DVE-2018-0001, retrying transaction with reduced feature level UDP.
910:Nov 13 15:57:14 ICA-RG-SingleVM-role-0 systemd-resolved[894]: message repeated 3 times: [ Server returned error NXDOMAIN, mitigating potential DNS violation DVE-2018-0001, retrying transaction with reduced feature level UDP.]

11/13/2018 03:57:54 PM : DEBUG : 636:Nov 13 15:56:59 ICA-RG-SingleVM-role-0 kernel: [   46.213653] random: 7 urandom warning(s) missed due to ratelimiting
758:Nov 13 15:57:03 ICA-RG-SingleVM-role-0 python3[1230]: 2018/11/13 15:57:01.946906 WARNING Server preferred version:2015-04-05
844:Nov 13 15:57:04 ICA-RG-SingleVM-role-0 python3[1230]: 2018/11/13 15:57:04.239088 WARNING Hostname record does not exist, creating [/var/lib/waagent/published_hostname] with hostname [ICA-RG-SingleVM-role-0]
867:Nov 13 15:57:05 ICA-RG-SingleVM-role-0 python3[1230]: 2018/11/13 15:57:05.185450 WARNING Dhcp client is not running.
913:Nov 13 15:57:14 ICA-RG-SingleVM-role-0 systemd[1]: Starting Write warning to Azure ephemeral disk...
914:Nov 13 15:57:14 ICA-RG-SingleVM-role-0 root: Added ephemeral disk warning to /mnt/DATALOSS_WARNING_README.txt
915:Nov 13 15:57:14 ICA-RG-SingleVM-role-0 systemd[1]: Started Write warning to Azure ephemeral disk.

11/13/2018 03:57:54 PM : DEBUG : 207:Nov 13 15:56:59 ICA-RG-SingleVM-role-0 kernel: [    0.420022] acpi PNP0A03:00: fail to add MMCONFIG information, can't access extended PCI configuration space under this bridge.

11/13/2018 03:57:54 PM : INFO : Checking ignorable boot ERROR/WARNING/FAILURE messages...
11/13/2018 03:57:54 PM : INFO : Ignorable ERROR/WARNING/FAILURE message: 207:Nov 13 15:56:59 ICA-RG-SingleVM-role-0 kernel: [    0.420022] acpi PNP0A03:00: fail to add MMCONFIG information, can't access extended PCI configuration space under this bridge.
11/13/2018 03:57:54 PM : INFO : Ignorable ERROR/WARNING/FAILURE message: 636:Nov 13 15:56:59 ICA-RG-SingleVM-role-0 kernel: [   46.213653] random: 7 urandom warning(s) missed due to ratelimiting
11/13/2018 03:57:54 PM : INFO : ERROR/WARNING/FAILURE are  present in kernel boot line.
11/13/2018 03:57:54 PM : INFO : Errors: 735:Nov 13 15:57:03 ICA-RG-SingleVM-role-0 HV_FCOPY: open /dev/vmbus/hv_fcopy failed; error: 2 No such file or directory782:Nov 13 15:57:03 ICA-RG-SingleVM-role-0 snapd[1266]: 2018/11/13 15:57:01.998696 helpers.go:119: error trying to compare the snap system key: system-key missing on disk909:Nov 13 15:57:14 ICA-RG-SingleVM-role-0 systemd-resolved[894]: Server returned error NXDOMAIN, mitigating potential DNS violation DVE-2018-0001, retrying transaction with reduced feature level UDP.910:Nov 13 15:57:14 ICA-RG-SingleVM-role-0 systemd-resolved[894]: message repeated 3 times: [ Server returned error NXDOMAIN, mitigating potential DNS violation DVE-2018-0001, retrying transaction with reduced feature level UDP.]
11/13/2018 03:57:54 PM : INFO : warnings: 758:Nov 13 15:57:03 ICA-RG-SingleVM-role-0 python3[1230]: 2018/11/13 15:57:01.946906 WARNING Server preferred version:2015-04-05844:Nov 13 15:57:04 ICA-RG-SingleVM-role-0 python3[1230]: 2018/11/13 15:57:04.239088 WARNING Hostname record does not exist, creating [/var/lib/waagent/published_hostname] with hostname [ICA-RG-SingleVM-role-0]867:Nov 13 15:57:05 ICA-RG-SingleVM-role-0 python3[1230]: 2018/11/13 15:57:05.185450 WARNING Dhcp client is not running.913:Nov 13 15:57:14 ICA-RG-SingleVM-role-0 systemd[1]: Starting Write warning to Azure ephemeral disk...914:Nov 13 15:57:14 ICA-RG-SingleVM-role-0 root: Added ephemeral disk warning to /mnt/DATALOSS_WARNING_README.txt915:Nov 13 15:57:14 ICA-RG-SingleVM-role-0 systemd[1]: Started Write warning to Azure ephemeral disk.

