### PR TITLE
hyperv: lower RAM for Standard_DS4_v2 flavor to 8192 MB

### DIFF
--- a/Libraries/HyperV.psm1
+++ b/Libraries/HyperV.psm1
@@ -864,7 +864,7 @@ Function Set-VMDynamicMemory
         return $False
     }
 
-} 
+}
 
 Function Get-VMDemandMemory {
     param (

--- a/XML/AzureVMSizeToHyperVMapping.xml
+++ b/XML/AzureVMSizeToHyperVMapping.xml
@@ -263,7 +263,8 @@
     </Standard_DS3_v2>
     <Standard_DS4_v2>
         <NumberOfCores>8</NumberOfCores>
-        <MemoryInMB>28672</MemoryInMB>
+        <!-- Azure flavor RAM size: 28672 -->
+        <MemoryInMB>8192</MemoryInMB>
     </Standard_DS4_v2>
     <Standard_DS5_v2>
         <NumberOfCores>16</NumberOfCores>


### PR DESCRIPTION
This change is needed not to use too much RAM on HyperV tests when executing BVT tests.