### PR TITLE
kernel_logs: fix initial log file

### DIFF
--- a/Libraries/CommonFunctions.psm1
+++ b/Libraries/CommonFunctions.psm1
@@ -747,7 +747,7 @@ Function GetAndCheckKernelLogs($allDeployedVMs, $status, $vmUser, $vmPassword) {
 			$finalBootLogFile = "FinalBootLogs.txt"
 			$initialBootLog = Join-Path $BootLogDir $initialBootLogFile
 			$finalBootLog = Join-Path $BootLogDir $finalBootLogFile
-			$currenBootLogFile = $finalBootLogFile
+			$currenBootLogFile = $initialBootLog
 			$currenBootLog = $initialBootLog
 			$kernelLogStatus = Join-Path $BootLogDir "KernelLogStatus.txt"
 


### PR DESCRIPTION
The current log file should be the initial log file, not the final log file.
This PR fixes the bad implementation.