### PR TITLE
kernel_logs: added error log and fix regression

### DIFF
--- a/Libraries/CommonFunctions.psm1
+++ b/Libraries/CommonFunctions.psm1
@@ -747,7 +747,7 @@ Function GetAndCheckKernelLogs($allDeployedVMs, $status, $vmUser, $vmPassword) {
 			$finalBootLogFile = "FinalBootLogs.txt"
 			$initialBootLog = Join-Path $BootLogDir $initialBootLogFile
 			$finalBootLog = Join-Path $BootLogDir $finalBootLogFile
-			$currenBootLogFile = $initialBootLog
+			$currenBootLogFile = $initialBootLogFile
 			$currenBootLog = $initialBootLog
 			$kernelLogStatus = Join-Path $BootLogDir "KernelLogStatus.txt"
 
@@ -757,7 +757,7 @@ Function GetAndCheckKernelLogs($allDeployedVMs, $status, $vmUser, $vmPassword) {
 			}
 
 			if ($status -imatch "Initial") {
-				$checkConnectivityFile = Join-Path $LogDir ([System.IO.Path]::GetcheckConnectivityFile())
+				$checkConnectivityFile = Join-Path $LogDir ([System.IO.Path]::GetRandomFileName())
 				Set-Content -Value "Test connectivity." -Path $checkConnectivityFile
 				RemoteCopy -uploadTo $VM.PublicIP -port $VM.SSHPort  -files $checkConnectivityFile `
 					-username $vmUser -password $vmPassword -upload | Out-Null
@@ -844,6 +844,7 @@ Function GetAndCheckKernelLogs($allDeployedVMs, $status, $vmUser, $vmPassword) {
 			}
 		}
 	} catch {
+		LogMsg $_
 		$retValue = $false
 	}
 


### PR DESCRIPTION
This patch fixes a code regression added in https://github.com/LIS/LISAv2/pull/411
 Execution tested on Ubuntu 16.04

```
11/21/2018 20:34:00 : [INFO ] Checking for call traces in kernel logs..
11/21/2018 20:34:00 : [INFO ] No kernel call traces found.
11/21/2018 20:34:00 : [INFO ] ** Initial and Final Kernel Logs have same content **
...
11/21/2018 20:34:09 : [INFO ] CleanUP Successful for ICA-HG-SingleVM-test-NVCX75226-636784363391..
11/21/2018 20:34:09 : [INFO ] ~~~~~~~~~~~~~~~TEST END : SQM-BASIC~~~~~~~~~~
11/21/2018 20:34:09 : [INFO ] CURRENT - PASS    - 1
11/21/2018 20:34:09 : [INFO ] CURRENT - FAIL    - 0
11/21/2018 20:34:09 : [INFO ] CURRENT - ABORTED - 0
```