### PR TITLE
penguinator: fix LogFileName in scripts

### DIFF
--- a/JenkinsPipelines/Scripts/InspectVHD.ps1
+++ b/JenkinsPipelines/Scripts/InspectVHD.ps1
@@ -27,8 +27,11 @@
 Param (
     $RemoteFolder = "J:\ReceivedFiles",
     $LocalFolder = "Q:\Temp",
+    $LogFileName = "InspectVHD.log",
     $XMLSecretFile = ""
 )
+
+Set-Variable -Name LogFileName -Value $LogFileName -Scope Global -Force
 
 Get-ChildItem .\Libraries -Recurse | Where-Object { $_.FullName.EndsWith(".psm1") } | ForEach-Object { Import-Module $_.FullName -Force -Global -DisableNameChecking }
 

--- a/JenkinsPipelines/Scripts/ReceivePartnerFiles.ps1
+++ b/JenkinsPipelines/Scripts/ReceivePartnerFiles.ps1
@@ -26,8 +26,11 @@
 
 param (
     [string]$SharedParentDirectory = "J:\ReceivedFiles",
+    [string]$LogFileName = "ReceivePartnerFiles.log",
     [string]$PartnerUsername
 )
+
+Set-Variable -Name LogFileName -Value $LogFileName -Scope Global -Force
 
 #Import Libraries
 Get-ChildItem .\Libraries -Recurse | Where-Object { $_.FullName.EndsWith(".psm1") } | ForEach-Object { Import-Module $_.FullName -Force -Global -DisableNameChecking }


### PR DESCRIPTION
PR #402 changed the way log filename is handled.
However, the Jenkinspipeline/Scripts are ran outside of Run-LisaV2.ps1 which now handles the log filename, so these were failing.

This has been tested internally and it fixed the launcher and test execution jobs.