### PR TITLE
Fix for SetupTypeName

### DIFF
--- a/XML/TestCases/FunctionalTests-SRIOV.xml
+++ b/XML/TestCases/FunctionalTests-SRIOV.xml
@@ -21,7 +21,7 @@
     </test>
     <test>
         <testName>VERIFY-IFUP-NICS-SRIOV</testName>
-        <setupType>1VM8NIC</setupType>
+        <setupType>OneVM8NIC</setupType>
         <AdditionalHWConfig>
             <Networking>SRIOV</Networking>
         </AdditionalHWConfig>

--- a/XML/TestCases/StressTests.xml
+++ b/XML/TestCases/StressTests.xml
@@ -18,7 +18,7 @@
         <testScript></testScript>
         <PowershellScript>STRESSTEST-VERIFY-RESTART.ps1</PowershellScript>
         <files></files>
-        <setupType>1VM8NIC</setupType>
+        <setupType>OneVM8NIC</setupType>
         <AdditionalHWConfig>
             <Networking>SRIOV</Networking>
         </AdditionalHWConfig>

--- a/XML/VMConfigurations/SmokeTestsConfigurations.xml
+++ b/XML/VMConfigurations/SmokeTestsConfigurations.xml
@@ -17,7 +17,7 @@
             </VirtualMachine>
         </ResourceGroup>
     </SingleVM>
-    <1VM8NIC>
+    <OneVM8NIC>
         <isDeployed>NO</isDeployed>
         <ResourceGroup>
             <VirtualMachine>
@@ -35,5 +35,5 @@
                 <ExtraNICs>7</ExtraNICs>
             </VirtualMachine>
         </ResourceGroup>
-    </1VM8NIC>
+    </OneVM8NIC>
 </TestSetup>


### PR DESCRIPTION
Introduced a bug with https://github.com/LIS/LISAv2/pull/462
This is fixing the issue of naming starting with a number - 1VM8NIC was
changed to OneVM8NIC