### PR TITLE
perf_framework: iperf3: output perf results in a generic way 

### DIFF
--- a/XML/Other/ReplaceableTestParameters.xml
+++ b/XML/Other/ReplaceableTestParameters.xml
@@ -139,4 +139,8 @@ Scenario 2 : You need to run all the performance tests quickly.
         <ReplaceThis>HYPERV_PERF_NIC_NAME</ReplaceThis>
         <ReplaceWith>SRIOV</ReplaceWith>
     </Parameter>
+    <Parameter>
+        <ReplaceThis>PERF-NETWORK-TCP-SINGLE-CONNECTION-THROUGHPUT-SYNTHETIC-BUFFER-LENGTHS</ReplaceThis>
+        <ReplaceWith>(32 64 128 256 512 1024 2048 4096 8192 16384 32768 65536)</ReplaceWith>
+    </Parameter>
 </ReplaceableTestParameters>

--- a/XML/TestCases/PerformanceTests.xml
+++ b/XML/TestCases/PerformanceTests.xml
@@ -332,7 +332,7 @@
         <Priority>2</Priority>
     </test>
     <test>
-        <testName>PERF-NETWORK-TCP-SINGLE-CONNECTION-THROUGHPUT-Synthetic</testName>
+        <testName>PERF-NETWORK-TCP-SINGLE-CONNECTION-THROUGHPUT-SYNTHETIC</testName>
         <testScript>PERF-NETWORK-TCP-SINGLE-CONNECTION-THROUGHPUT.ps1</testScript>
         <setupType>M1S1</setupType>
         <AdditionalHWConfig>
@@ -349,7 +349,7 @@
             <param>testType=tcp</param>
             <param>max_parallel_connections_per_instance=64</param>
             <param>connections=(1)</param>
-            <param>bufferLengths=(32 64 128 256 512 1024 2048 4096 8192 16384 32768 65536)</param>
+            <param>bufferLengths=PERF-NETWORK-TCP-SINGLE-CONNECTION-THROUGHPUT-SYNTHETIC-BUFFER-LENGTHS</param>
             <param>IPversion=4</param>
         </TestParameters>
         <Platform>Azure,HyperV</Platform>


### PR DESCRIPTION
To compare the results for the performance testing, we need a framework that:

- is generic - should work for all performance results
- has machine readable output

For genericity, all performance test cases should have a JSON output, with the name 

> TestCaseName_perf_results.json

The JSON file should contain an array of objects, with the object having the following structure
{
  "Id": ValueID,
 "ResultType1": Value1,
 "ResultType2": Value2,
 "ResultType3": Value3
}

Is mandatory to have at least the Id field.

This has to be implemented for all performance test cases to be able to have a comparison of the results.
If the test does not implement, there will be no result comparison possible.

The changes in the other test cases should require refactoring and adding this feature.
This feature is backwards compatible with the previous workflow.