### PR TITLE
stor_perf: fix backwards compatibility in params

### DIFF
--- a/Testscripts/Linux/perf_fio.sh
+++ b/Testscripts/Linux/perf_fio.sh
@@ -84,7 +84,7 @@ RunFIO()
 	#
 
 	#All possible values for file-test-mode are randread randwrite read write
-	#modes='randread randwrite read write'
+	#modes=(randread randwrite read write)
 	iteration=0
 	#startThread=1
 	#startIO=8
@@ -116,7 +116,7 @@ RunFIO()
 	fio --cpuclock-test >> $LOGFILE
 	####################################
 	#Trigger run from here
-	for testmode in $modes; do
+	for testmode in "${modes[@]}"; do
 		io=$startIO
 		while [ $io -le $maxIO ]
 		do


### PR DESCRIPTION
The storage bash scripts require arrays to be defined as:
'val1 val2'

and not:
(val1 val2)

This patch fixes perf_fio.sh to manage arrays given as (val1 val2)