### PR TITLE
lisav2: fix azure secrets load

### DIFF
--- a/Run-LisaV2.ps1
+++ b/Run-LisaV2.ps1
@@ -142,16 +142,9 @@ try {
 	foreach ($var in $GlobalVariables) {
 		[void](Set-Variable -Name $var.Name -Value $var.Value -Scope Local -ErrorAction SilentlyContinue)
 	}
+
 	# Validate the test parameters.
 	Validate-Parameters
-
-	# Validate all the XML files and then import test cases from them for test
-	Validate-XmlFiles -ParentFolder $WorkingDirectory
-	$TestConfigurationXmlFile = "$WorkingDirectory\TestConfiguration.xml"
-	Import-TestCases $WorkingDirectory $TestConfigurationXmlFile
-	# Inject default / custom replaceable test parameters to TestConfiguration.xml
-	$ReplaceableTestParameters = [xml](Get-Content -Path "$WorkingDirectory\XML\Other\ReplaceableTestParameters.xml")
-	Inject-CustomTestParameters $CustomParameters $ReplaceableTestParameters $TestConfigurationXmlFile
 
 	# Handle the Secrets file
 	if ($env:Azure_Secrets_File) {
@@ -179,6 +172,14 @@ try {
 	} else {
 		Write-LogErr "Failed to update configuration files. '-XMLSecretFile [FilePath]' is not provided."
 	}
+
+	# Validate all the XML files and then import test cases from them for test
+	Validate-XmlFiles -ParentFolder $WorkingDirectory
+	$TestConfigurationXmlFile = "$WorkingDirectory\TestConfiguration.xml"
+	Import-TestCases $WorkingDirectory $TestConfigurationXmlFile
+	# Inject default / custom replaceable test parameters to TestConfiguration.xml
+	$ReplaceableTestParameters = [xml](Get-Content -Path "$WorkingDirectory\XML\Other\ReplaceableTestParameters.xml")
+	Inject-CustomTestParameters $CustomParameters $ReplaceableTestParameters $TestConfigurationXmlFile
 
 	# Create report folder
 	$reportFolder = "$pwd/Report"


### PR DESCRIPTION
This patch fixes the azure secrets load failure.
Without this patch, lisav2 fails with error:

> [azure] Select-AzureRmSubscription : Please provide a valid tenant or a
> valid
> [azure] subscription.
> [azure] At C:\LISAv2\FGNS14927\AutomationManager.ps1:417 char:27
> [azure] + ... scription = Select-AzureRmSubscription -SubscriptionId
> $AzureSetup.Su ...
> [azure] 
> [azure]     + CategoryInfo          : CloseError: (:)
> [Set-AzureRmContext], ArgumentEx
> [azure]    ception
> [azure]     + FullyQualifiedErrorId :
> Microsoft.Azure.Commands.Profile.SetAzureRMConte
> [azure]    xtCommand
> 
> 

The problem was introduced by commit:
https://github.com/LIS/LISAv2/commit/087bfca718cc72d5d9a27790d7f71c6e35b5255d