### PR TITLE
lisav2: initialize $testSummary for every test run

### DIFF
--- a/AutomationManager.ps1
+++ b/AutomationManager.ps1
@@ -202,10 +202,10 @@ Function Run-TestsOnCycle ([string] $cycleName, [xml] $xmlConfig, [string] $Dist
 					$junitReport.StartLogTestCase("LISAv2Test","$currentTestName","$($testCycle.cycleName)")
 
 					Set-Variable -Name currentTestData -Value $currentTestData -Scope Global
+					$testResult = ""
+					$testSummary = ""
+					Write-LogInfo "~~~~~~~~~~~~~~~TEST STARTED : $currentTestName~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 					try	{
-						$testResult = @()
-						Write-LogInfo "~~~~~~~~~~~~~~~TEST STARTED : $currentTestName~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-
 						$CurrentTestResult = Run-Test -CurrentTestData $currentTestData -XmlConfig $xmlConfig `
 							-Distro $Distro -LogDir $CurrentTestLogDir -VMUser $user -VMPassword $password `
 							-ExecuteSetup $shouldRunSetupForIteration -ExecuteTeardown $shouldRunTeardownForIteration


### PR DESCRIPTION
$testSummary wasn't initialized when a test exception occured. This meant that a previously set $testSummary variable was passed to an aborted test. This fixes https://github.com/LIS/LISAv2/issues/523 
- Moved $testSummary & $testResult var init outside the try-catch block

## Before this PR
ARM Image Under Test  : Canonical : UbuntuServer : 18.10 : latest
Total Test Cases      : 36 (21 Pass, 0 Fail, 15 Abort)
Total Time (dd:hh:mm) : 0:4:11
XML File              : TestConfiguration

   ID TestCaseName                                                 TestResult TestDuration(in minutes) 
------------------------------------------------------------------------------------------------------
    1 BVT-VERIFY-DEPLOYMENT-PROVISION                                    PASS                 7.63 
	FirstBoot : PASS 
	FirstBoot : Call Trace Verification : PASS 
	Reboot : PASS 
	Reboot : Call Trace Verification : PASS 
    2 BVT-IS-ROOT-PASSWORD-DELETED                                    ABORTED                 0.99 
	FirstBoot : PASS 
	FirstBoot : Call Trace Verification : PASS 
	Reboot : PASS 
	Reboot : Call Trace Verification : PASS 

## After this PR
ARM Image Under Test  : Canonical : UbuntuServer : 18.10 : latest
Total Test Cases      : 2 (1 Pass, 0 Fail, 1 Abort)
Total Time (dd:hh:mm) : 0:0:11
XML File              : TestConfiguration

   ID TestCaseName                                                 TestResult TestDuration(in minutes)
------------------------------------------------------------------------------------------------------
    1 BVT-VERIFY-DEPLOYMENT-PROVISION                                    PASS                 6.08
        FirstBoot : PASS
        FirstBoot : Call Trace Verification : PASS
        Reboot : PASS
        Reboot : Call Trace Verification : PASS
    2 BVT-IS-ROOT-PASSWORD-DELETED                                    ABORTED                 4.22

