### PR TITLE
Added Location param to Get-AzureRmStorageUsage

### DIFF
--- a/Libraries/Azure.psm1
+++ b/Libraries/Azure.psm1
@@ -267,7 +267,7 @@ Function Validate-SubscriptionUsage($subscriptionID, $RGXMLData) {
 
     #region Storage Accounts
     Write-LogInfo "Estimating storage account usage..."
-    $currentStorageStatus = Get-AzureRmStorageUsage
+    $currentStorageStatus = Get-AzureRmStorageUsage -Location $Location
     if ( ($premiumVMs -gt 0 ) -and ($xmlConfig.config.$TestPlatform.General.StorageAccount -imatch "NewStorage_")) {
         $requiredStorageAccounts = 1
     }


### PR DESCRIPTION
Added Location param to  Get-AzureRmStorageUsage command-let inorder to remove below warning

[INFO ] Estimating storage account usage...
WARNING: Get global storage usage is obsolete, please use get location usage
with -Location Parameter instead.

Test Results Summary

[LISAv2 Test Results Summary]
Test Run On           : 12/17/2018 12:22:10
ARM Image Under Test  : OpenLogic : CentOS : 7.5 : 7.5.20180815
Total Test Cases      : 1 (1 Pass, 0 Fail, 0 Abort)
Total Time (dd:hh:mm) : 0:0:13
XML File              : TestConfiguration

   ID TestCaseName                                                 TestResult TestDuration(in minutes)
------------------------------------------------------------------------------------------------------
    1 BVT-ROOT-DEVICE-TIMEOUT-CHECK                                      PASS                 7.08

12/17/2018 12:22:13 : [INFO ]   Current standardDSv2Family usage : 1 cores. Requested:1. Estimated usage=2. Max Allowed cores:100/100
>> 12/17/2018 12:22:13 : [INFO ] Estimating storage account usage...
12/17/2018 12:22:15 : [INFO ] Current Storage Accounts usage:3. Requested:1. Estimated usage:4. Maximum allowed:200/200.
12/17/2018 12:22:16 : [INFO ] Current Public IPs usage:2. Requested: 1. Estimated usage:3. Maximum allowed: 1000.
