### PR TITLE
lisav2: allow multiple test categories, comma separated

### DIFF
--- a/Libraries/LISAV2-Framework.psm1
+++ b/Libraries/LISAV2-Framework.psm1
@@ -359,7 +359,7 @@ Function Collect-TestCases($TestXMLs)
                 continue
             }
 
-            if (($test.Category -ne $TestCategory) -and ($TestCategory -ne "*")) {
+            if (!($TestCategory.Split(",").Contains($test.Category)) -and ($TestCategory -ne "*")) {
                 continue
             }
 


### PR DESCRIPTION
This commit allows specifying multiple test categories, instead of none or only one.