### PR TITLE
Add ignorable boot errors and warnings for ubuntu 18.04 on Azure

### DIFF
--- a/XML/Other/ignorable-boot-errors.xml
+++ b/XML/Other/ignorable-boot-errors.xml
@@ -1,5 +1,5 @@
 <!--#This list contains the ignorable boot errors of different images.-->
-<messages>		
+<messages>
         <failures>
             <keywords>Perf event create on CPU 0 failed with -2</keywords>
             <keywords>Fast TSC calibration</keywords>
@@ -21,13 +21,22 @@
             <keywords>Failed to access perfctr msr</keywords>
         </failures>
         <errors>
+            <keywords>error trying to compare the snap system key: system-key missing on disk</keywords>
+            <keywords>open /dev/vmbus/hv_fcopy failed; error: 2 No such file or directory</keywords>
+            <keywords>mitigating potential DNS violation DVE-2018-0001</keywords>
             <keywords>end_request: I/O error, dev fd0, sector 0</keywords>
             <keywords>blk_update_request: I/O error, dev fd0, sector 0</keywords>
             <keywords>floppy: error -5 while reading block 0</keywords>
             <keywords>Broken pipe</keywords>
-            <keywords>errors=remount-ro</keywords>			
+            <keywords>errors=remount-ro</keywords>
         </errors>
         <warnings>
+            <keywords>Server preferred version:</keywords>
+            <keywords>WARNING Hostname record does not exist,</keywords>
+            <keywords>WARNING Dhcp client is not running</keywords>
+            <keywords>Starting Write warning to Azure ephemeral disk</keywords>
+            <keywords>Added ephemeral disk warning to</keywords>
+            <keywords>Started Write warning to Azure ephemeral disk</keywords>
             <keywords>Proceeding WITHOUT firewalling in effect!</keywords>
             <keywords>urandom warning(s) missed due to ratelimiting</keywords>
         </warnings>


### PR DESCRIPTION
Adressing issue #516 
**Before fix :** 

Output : 

01/03/2019 08:56:36 AM : INFO : Checking for ERROR and WARNING messages in  kernel boot line.
01/03/2019 08:56:36 AM : DEBUG : 713:Jan  3 08:55:44 LISAv2-OneVM-staginglisav2-LO91-20190103085323-role-0 HV_FCOPY: open /dev/vmbus/hv_fcopy failed; error: 2 No such file or directory
825:Jan  3 08:55:47 LISAv2-OneVM-staginglisav2-LO91-20190103085323-role-0 snapd[1355]: 2019/01/03 08:55:47.971567 helpers.go:119: error trying to compare the snap system key: system-key missing on disk
910:Jan  3 08:55:58 LISAv2-OneVM-staginglisav2-LO91-20190103085323-role-0 systemd-resolved[930]: Server returned error NXDOMAIN, mitigating potential DNS violation DVE-2018-0001, retrying transaction with reduced feature level UDP.
911:Jan  3 08:55:58 LISAv2-OneVM-staginglisav2-LO91-20190103085323-role-0 systemd-resolved[930]: message repeated 3 times: [ Server returned error NXDOMAIN, mitigating potential DNS violation DVE-2018-0001, retrying transaction with reduced feature level UDP.]

01/03/2019 08:56:36 AM : DEBUG : 473:Jan  3 08:55:44 LISAv2-OneVM-staginglisav2-LO91-20190103085323-role-0 kernel: [   18.928058] random: 7 urandom warning(s) missed due to ratelimiting
820:Jan  3 08:55:47 LISAv2-OneVM-staginglisav2-LO91-20190103085323-role-0 python3[1338]: 2019/01/03 08:55:47.320013 WARNING Server preferred version:2015-04-05
845:Jan  3 08:55:48 LISAv2-OneVM-staginglisav2-LO91-20190103085323-role-0 python3[1338]: 2019/01/03 08:55:48.986531 WARNING Hostname record does not exist, creating [/var/lib/waagent/published_hostname] with hostname [LISAv2-OneVM-staginglisav2-LO91-20190103085323-role-0]
869:Jan  3 08:55:50 LISAv2-OneVM-staginglisav2-LO91-20190103085323-role-0 python3[1338]: 2019/01/03 08:55:50.077998 WARNING Dhcp client is not running.
914:Jan  3 08:55:58 LISAv2-OneVM-staginglisav2-LO91-20190103085323-role-0 systemd[1]: Starting Write warning to Azure ephemeral disk...
915:Jan  3 08:55:58 LISAv2-OneVM-staginglisav2-LO91-20190103085323-role-0 systemd[1]: Started Write warning to Azure ephemeral disk.
916:Jan  3 08:55:58 LISAv2-OneVM-staginglisav2-LO91-20190103085323-role-0 root: Added ephemeral disk warning to /mnt/DATALOSS_WARNING_README.txt

01/03/2019 08:56:36 AM : DEBUG : 209:Jan  3 08:55:44 LISAv2-OneVM-staginglisav2-LO91-20190103085323-role-0 kernel: [    0.456010] acpi PNP0A03:00: fail to add MMCONFIG information, can't access extended PCI configuration space under this bridge.

01/03/2019 08:56:37 AM : INFO : Checking ignorable boot ERROR/WARNING/FAILURE messages...
01/03/2019 08:56:37 AM : INFO : Ignorable ERROR/WARNING/FAILURE message: 209:Jan  3 08:55:44 LISAv2-OneVM-staginglisav2-LO91-20190103085323-role-0 kernel: [    0.456010] acpi PNP0A03:00: fail to add MMCONFIG information, can't access extended PCI configuration space under this bridge.
01/03/2019 08:56:37 AM : INFO : Ignorable ERROR/WARNING/FAILURE message: 473:Jan  3 08:55:44 LISAv2-OneVM-staginglisav2-LO91-20190103085323-role-0 kernel: [   18.928058] random: 7 urandom warning(s) missed due to ratelimiting
01/03/2019 08:56:37 AM : INFO : ERROR/WARNING/FAILURE are  present in kernel boot line.
01/03/2019 08:56:37 AM : INFO : Errors: 713:Jan  3 08:55:44 LISAv2-OneVM-staginglisav2-LO91-20190103085323-role-0 HV_FCOPY: open /dev/vmbus/hv_fcopy failed; error: 2 No such file or directory825:Jan  3 08:55:47 LISAv2-OneVM-staginglisav2-LO91-20190103085323-role-0 snapd[1355]: 2019/01/03 08:55:47.971567 helpers.go:119: error trying to compare the snap system key: system-key missing on disk910:Jan  3 08:55:58 LISAv2-OneVM-staginglisav2-LO91-20190103085323-role-0 systemd-resolved[930]: Server returned error NXDOMAIN, mitigating potential DNS violation DVE-2018-0001, retrying transaction with reduced feature level UDP.911:Jan  3 08:55:58 LISAv2-OneVM-staginglisav2-LO91-20190103085323-role-0 systemd-resolved[930]: message repeated 3 times: [ Server returned error NXDOMAIN, mitigating potential DNS violation DVE-2018-0001, retrying transaction with reduced feature level UDP.]
01/03/2019 08:56:37 AM : INFO : warnings: 820:Jan  3 08:55:47 LISAv2-OneVM-staginglisav2-LO91-20190103085323-role-0 python3[1338]: 2019/01/03 08:55:47.320013 WARNING Server preferred version:2015-04-05845:Jan  3 08:55:48 LISAv2-OneVM-staginglisav2-LO91-20190103085323-role-0 python3[1338]: 2019/01/03 08:55:48.986531 WARNING Hostname record does not exist, creating [/var/lib/waagent/published_hostname] with hostname [LISAv2-OneVM-staginglisav2-LO91-20190103085323-role-0]869:Jan  3 08:55:50 LISAv2-OneVM-staginglisav2-LO91-20190103085323-role-0 python3[1338]: 2019/01/03 08:55:50.077998 WARNING Dhcp client is not running.914:Jan  3 08:55:58 LISAv2-OneVM-staginglisav2-LO91-20190103085323-role-0 systemd[1]: Starting Write warning to Azure ephemeral disk...915:Jan  3 08:55:58 LISAv2-OneVM-staginglisav2-LO91-20190103085323-role-0 systemd[1]: Started Write warning to Azure ephemeral disk.916:Jan  3 08:55:58 LISAv2-OneVM-staginglisav2-LO91-20190103085323-role-0 root: Added ephemeral disk warning to /mnt/DATALOSS_WARNING_README.txt

[azure] ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : latest
[azure] Total Test Cases      : 1 (0 Pass, 1 Fail, 0 Abort)
[azure] Total Time (dd:hh:mm) : 0:0:3
[azure] XML File              : TestConfiguration
[azure] 
[azure]    ID TestCaseName                                                 TestResult TestDuration(in minutes) 
[azure] ------------------------------------------------------------------------------------------------------
[azure]     1 BVT-VERIFY-BOOT-ERROR-WARNINGS                                     FAIL                 3.57 

**After fix :** 

Ouput: 

01/03/2019 11:21:11 AM : INFO : Checking for ERROR and WARNING messages in  kernel boot line.
01/03/2019 11:21:12 AM : DEBUG : 713:Jan  3 11:20:30 LISAv2-OneVM-staginglisav2-QB12-20190103111820-role-0 HV_FCOPY: open /dev/vmbus/hv_fcopy failed; error: 2 No such file or directory
816:Jan  3 11:20:31 LISAv2-OneVM-staginglisav2-QB12-20190103111820-role-0 snapd[1288]: 2019/01/03 11:20:31.178647 helpers.go:119: error trying to compare the snap system key: system-key missing on disk
913:Jan  3 11:20:38 LISAv2-OneVM-staginglisav2-QB12-20190103111820-role-0 systemd-resolved[894]: Server returned error NXDOMAIN, mitigating potential DNS violation DVE-2018-0001, retrying transaction with reduced feature level UDP.
914:Jan  3 11:20:38 LISAv2-OneVM-staginglisav2-QB12-20190103111820-role-0 systemd-resolved[894]: message repeated 3 times: [ Server returned error NXDOMAIN, mitigating potential DNS violation DVE-2018-0001, retrying transaction with reduced feature level UDP.]

01/03/2019 11:21:12 AM : DEBUG : 472:Jan  3 11:20:29 LISAv2-OneVM-staginglisav2-QB12-20190103111820-role-0 kernel: [   17.511446] random: 7 urandom warning(s) missed due to ratelimiting
824:Jan  3 11:20:31 LISAv2-OneVM-staginglisav2-QB12-20190103111820-role-0 python3[1228]: 2019/01/03 11:20:31.365998 WARNING Server preferred version:2015-04-05
845:Jan  3 11:20:33 LISAv2-OneVM-staginglisav2-QB12-20190103111820-role-0 python3[1228]: 2019/01/03 11:20:33.251800 WARNING Hostname record does not exist, creating [/var/lib/waagent/published_hostname] with hostname [LISAv2-OneVM-staginglisav2-QB12-20190103111820-role-0]
868:Jan  3 11:20:34 LISAv2-OneVM-staginglisav2-QB12-20190103111820-role-0 python3[1228]: 2019/01/03 11:20:34.270370 WARNING Dhcp client is not running.
917:Jan  3 11:20:38 LISAv2-OneVM-staginglisav2-QB12-20190103111820-role-0 systemd[1]: Starting Write warning to Azure ephemeral disk...
918:Jan  3 11:20:38 LISAv2-OneVM-staginglisav2-QB12-20190103111820-role-0 root: Added ephemeral disk warning to /mnt/DATALOSS_WARNING_README.txt
919:Jan  3 11:20:38 LISAv2-OneVM-staginglisav2-QB12-20190103111820-role-0 systemd[1]: Started Write warning to Azure ephemeral disk.

01/03/2019 11:21:12 AM : DEBUG : 208:Jan  3 11:20:29 LISAv2-OneVM-staginglisav2-QB12-20190103111820-role-0 kernel: [    0.364021] acpi PNP0A03:00: fail to add MMCONFIG information, can't access extended PCI configuration space under this bridge.

01/03/2019 11:21:12 AM : INFO : Checking ignorable boot ERROR/WARNING/FAILURE messages...
01/03/2019 11:21:12 AM : INFO : Ignorable ERROR/WARNING/FAILURE message: 208:Jan  3 11:20:29 LISAv2-OneVM-staginglisav2-QB12-20190103111820-role-0 kernel: [    0.364021] acpi PNP0A03:00: fail to add MMCONFIG information, can't access extended PCI configuration space under this bridge.
01/03/2019 11:21:12 AM : INFO : Ignorable ERROR/WARNING/FAILURE message: 713:Jan  3 11:20:30 LISAv2-OneVM-staginglisav2-QB12-20190103111820-role-0 HV_FCOPY: open /dev/vmbus/hv_fcopy failed; error: 2 No such file or directory
01/03/2019 11:21:12 AM : INFO : Ignorable ERROR/WARNING/FAILURE message: 816:Jan  3 11:20:31 LISAv2-OneVM-staginglisav2-QB12-20190103111820-role-0 snapd[1288]: 2019/01/03 11:20:31.178647 helpers.go:119: error trying to compare the snap system key: system-key missing on disk
01/03/2019 11:21:12 AM : INFO : Ignorable ERROR/WARNING/FAILURE message: 913:Jan  3 11:20:38 LISAv2-OneVM-staginglisav2-QB12-20190103111820-role-0 systemd-resolved[894]: Server returned error NXDOMAIN, mitigating potential DNS violation DVE-2018-0001, retrying transaction with reduced feature level UDP.
01/03/2019 11:21:12 AM : INFO : Ignorable ERROR/WARNING/FAILURE message: 914:Jan  3 11:20:38 LISAv2-OneVM-staginglisav2-QB12-20190103111820-role-0 systemd-resolved[894]: message repeated 3 times: [ Server returned error NXDOMAIN, mitigating potential DNS violation DVE-2018-0001, retrying transaction with reduced feature level UDP.]
01/03/2019 11:21:12 AM : INFO : Ignorable ERROR/WARNING/FAILURE message: 472:Jan  3 11:20:29 LISAv2-OneVM-staginglisav2-QB12-20190103111820-role-0 kernel: [   17.511446] random: 7 urandom warning(s) missed due to ratelimiting
01/03/2019 11:21:12 AM : INFO : Ignorable ERROR/WARNING/FAILURE message: 824:Jan  3 11:20:31 LISAv2-OneVM-staginglisav2-QB12-20190103111820-role-0 python3[1228]: 2019/01/03 11:20:31.365998 WARNING Server preferred version:2015-04-05
01/03/2019 11:21:12 AM : INFO : Ignorable ERROR/WARNING/FAILURE message: 845:Jan  3 11:20:33 LISAv2-OneVM-staginglisav2-QB12-20190103111820-role-0 python3[1228]: 2019/01/03 11:20:33.251800 WARNING Hostname record does not exist, creating [/var/lib/waagent/published_hostname] with hostname [LISAv2-OneVM-staginglisav2-QB12-20190103111820-role-0]
01/03/2019 11:21:12 AM : INFO : Ignorable ERROR/WARNING/FAILURE message: 868:Jan  3 11:20:34 LISAv2-OneVM-staginglisav2-QB12-20190103111820-role-0 python3[1228]: 2019/01/03 11:20:34.270370 WARNING Dhcp client is not running.
01/03/2019 11:21:12 AM : INFO : Ignorable ERROR/WARNING/FAILURE message: 917:Jan  3 11:20:38 LISAv2-OneVM-staginglisav2-QB12-20190103111820-role-0 systemd[1]: Starting Write warning to Azure ephemeral disk...
01/03/2019 11:21:12 AM : INFO : Ignorable ERROR/WARNING/FAILURE message: 918:Jan  3 11:20:38 LISAv2-OneVM-staginglisav2-QB12-20190103111820-role-0 root: Added ephemeral disk warning to /mnt/DATALOSS_WARNING_README.txt
01/03/2019 11:21:12 AM : INFO : Ignorable ERROR/WARNING/FAILURE message: 919:Jan  3 11:20:38 LISAv2-OneVM-staginglisav2-QB12-20190103111820-role-0 systemd[1]: Started Write warning to Azure ephemeral disk.

[azure] ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : latest
[azure] Total Test Cases      : 1 (1 Pass, 0 Fail, 0 Abort)
[azure] Total Time (dd:hh:mm) : 0:0:3
[azure] XML File              : TestConfiguration
[azure] 
[azure]    ID TestCaseName                                                 TestResult TestDuration(in minutes) 
[azure] ------------------------------------------------------------------------------------------------------
[azure]     1 BVT-VERIFY-BOOT-ERROR-WARNINGS                                     PASS                  3.2 
