### PR TITLE
Replace PowershellScript with testScript as init script for test cases

### DIFF
--- a/Testscripts/Windows/STRESSTEST-VERIFY-RESTART.ps1
+++ b/Testscripts/Windows/STRESSTEST-VERIFY-RESTART.ps1
@@ -60,6 +60,7 @@ function Main {
             $resultArr += $testResult
         }
     }
+    $rebootNr--
     Write-LogInfo "Reboot Stress Test Result: $rebootNr/$rebootNumber"
     if (($rebootNr - 1) -lt $rebootNumber) {
         $testResult = "FAIL"

--- a/XML/TestCases/FunctionalTests-SRIOV.xml
+++ b/XML/TestCases/FunctionalTests-SRIOV.xml
@@ -28,7 +28,6 @@
         <TestParameters>
             <param>network_interface_count=8</param>
         </TestParameters>
-        <PowershellScript>VERIFY-TEST-SCRIPT-IN-LINUX-GUEST.ps1</PowershellScript>
         <testScript>verify-ifup-nics.sh</testScript>
         <files>.\Testscripts\Linux\verify-ifup-nics.sh,.\TestScripts\Linux\utils.sh</files>
         <Platform>Azure</Platform>

--- a/XML/TestCases/StressTests.xml
+++ b/XML/TestCases/StressTests.xml
@@ -15,8 +15,7 @@
     </test>
     <test>
         <testName>STRESSTEST-VERIFY-RESTART-MAX-SRIOV-NICS</testName>
-        <testScript></testScript>
-        <PowershellScript>STRESSTEST-VERIFY-RESTART.ps1</PowershellScript>
+        <testScript>STRESSTEST-VERIFY-RESTART.ps1</testScript>
         <files></files>
         <setupType>OneVM8NICs</setupType>
         <AdditionalHWConfig>


### PR DESCRIPTION
STRESSTEST-VERIFY-RESTART-MAX-SRIOV-NICS current it didn't go into STRESSTEST-VERIFY-RESTART.ps1 because our framework start from testScript.
Remove PowershellScript section from VERIFY-IFUP-NICS-SRIOV, this file (VERIFY-TEST-SCRIPT-IN-LINUX-GUEST.ps1) doesn't exist.

Test results
[LISAv2 Test Results Summary]
Test Run On           : 01/09/2019 05:15:48
ARM Image Under Test  : canonical : ubuntuserver : 18.04-lts : Latest
Total Test Cases      : 2 (2 Pass, 0 Fail, 0 Abort)
Total Time (dd:hh:mm) : 0:0:17
XML File              : TestConfiguration

   ID TestCaseName                                                 TestResult TestDuration(in minutes) 
------------------------------------------------------------------------------------------------------
    1 VERIFY-IFUP-NICS-SRIOV                                             PASS                 6.61 
    2 STRESSTEST-VERIFY-RESTART-MAX-SRIOV-NICS                           PASS                 5.45 