### PR TITLE
hyperv: update IP in allVmData in case it has changed after reboot

### DIFF
--- a/Testscripts/Windows/BVT-NET-IFUP-IFDOWN.ps1
+++ b/Testscripts/Windows/BVT-NET-IFUP-IFDOWN.ps1
@@ -29,6 +29,7 @@ function Main {
         if ($TestPlatform -eq "HyperV") {
             $newIp = Get-IPv4AndWaitForSSHStart -VMName $VMName -HvServer $HvServer `
                 -VmPort $VmPort -User $VMUserName -Password $VMPassword -StepTimeout 30
+            $allVmData.PublicIP = $newIp
         }
         else {
             $newIp = $allVmData.PublicIP


### PR DESCRIPTION
During run BVT-NET-IFUP-IFDOWN, the IP will change. 
Before fix, the collect log will still against the old ip.

01/15/2019 07:10:29 : [INFO ] Collecting LISAv2-OneVM-upstreamk-GK24-636831035060-role-0 VM Kernel Final Logs...
01/15/2019 07:10:29 : [INFO ] dos2unix: converting file E:\lili\upstream\Test\TestResults\2019-14-01-22-58-23-7452\BVT-NET-IFUP-IFDOWN\runtest.sh to Unix format...
01/15/2019 07:10:29 : [INFO ] Uploading E:\lili\upstream\Test\TestResults\2019-14-01-22-58-23-7452\BVT-NET-IFUP-IFDOWN\runtest.sh to lisa : 10.156.76.66, port 22 using Password authentication
01/15/2019 07:10:51 : [WARN ] Error in upload, Attempt 1. Retrying for upload
0
...
01/15/2019 07:15:42 : [INFO ] Calling function - Copy-RemoteFiles. Error in upload after 11 Attempt,Hence giving up
01/15/2019 07:19:37 : [INFO ] dos2unix: converting file .\Testscripts\Linux\CollectLogFile.sh to Unix format...
01/15/2019 07:19:37 : [INFO ] Uploading .\Testscripts\Linux\CollectLogFile.sh to lisa : 10.156.76.66, port 22 using Password authentication
01/15/2019 07:19:59 : [WARN ] Error in upload, Attempt 1. Retrying for upload
...
01/15/2019 07:24:50 : [ERROR] EXCEPTION : Calling function - Copy-RemoteFiles. Error in upload after 11 Attempt,Hence giving up

After fix, no such issue

[LISAv2-Test-SB51.log](https://github.com/LIS/LISAv2/files/2758603/LISAv2-Test-SB51.log)
