### PR TITLE
unit_tests: added azure controller unit tests

### DIFF
--- a/Libraries/Azure.psm1
+++ b/Libraries/Azure.psm1
@@ -2429,3 +2429,49 @@ Function Get-StorageAccountFromRegion($Region,$StorageAccount)
 	Write-LogInfo "Selected : $StorageAccountName"
 	return $StorageAccountName
 }
+
+function Add-AzureAccountFromSecretsFile {
+	param(
+		$CustomSecretsFilePath
+	)
+
+	if ($env:Azure_Secrets_File) {
+		$secretsFile = $env:Azure_Secrets_File
+		Write-LogInfo "Using secrets file: $secretsFile, defined in environments."
+	} elseif ( $CustomSecretsFilePath ) {
+		$secretsFile = $CustomSecretsFilePath
+		Write-LogInfo "Using provided secrets file: $secretsFile"
+	}
+
+	if ( ($null -eq $secretsFile) -or ($secretsFile -eq [string]::Empty)) {
+		Write-LogErr "ERROR: The Secrets file is not being set."
+		Raise-Exception ("XML Secrets file not provided")
+	}
+
+	if ( Test-Path $secretsFile ) {
+		Write-LogInfo "$secretsFile found."
+		Write-LogInfo "------------------------------------------------------------------"
+		Write-LogInfo "Authenticating Azure PS session.."
+		$XmlSecrets = [xml](Get-Content $secretsFile)
+		$ClientID = $XmlSecrets.secrets.SubscriptionServicePrincipalClientID
+		$TenantID = $XmlSecrets.secrets.SubscriptionServicePrincipalTenantID
+		$Key = $XmlSecrets.secrets.SubscriptionServicePrincipalKey
+		$pass = ConvertTo-SecureString $key -AsPlainText -Force
+		$mycred = New-Object System.Management.Automation.PSCredential ($ClientID, $pass)
+		$subIDSplitted = ($XmlSecrets.secrets.SubscriptionID).Split("-")
+		$subIDMasked = "$($subIDSplitted[0])-xxxx-xxxx-xxxx-$($subIDSplitted[4])"
+
+		$null = Add-AzureRmAccount -ServicePrincipal -Tenant $TenantID -Credential $mycred
+		$selectedSubscription = Select-AzureRmSubscription -SubscriptionId $XmlSecrets.secrets.SubscriptionID
+		if ( $selectedSubscription.Subscription.Id -eq $XmlSecrets.secrets.SubscriptionID ) {
+			Write-LogInfo "Current Subscription : $subIDMasked."
+		} else {
+			Write-LogInfo "There was an error when selecting $subIDMasked."
+		}
+		Write-LogInfo "------------------------------------------------------------------"
+	}
+	else {
+		Write-LogErr "Secret file $secretsFile does not exist"
+		Raise-Exception ("XML Secrets file not provided")
+	}
+}

--- a/TestControllers/AzureController.psm1
+++ b/TestControllers/AzureController.psm1
@@ -89,11 +89,10 @@ Class AzureController : TestController
 			$azureConfig.ResultsDatabase.user = $secrets.DatabaseUser
 			$azureConfig.ResultsDatabase.password = $secrets.DatabasePassword
 			$azureConfig.ResultsDatabase.dbname = $secrets.DatabaseName
-			.\Utilities\AddAzureRmAccountFromSecretsFile.ps1 -customSecretsFilePath $XMLSecretFile
+			Add-AzureAccountFromSecretsFile -CustomSecretsFilePath $XMLSecretFile
 		}
 		$this.VmUsername = $azureConfig.TestCredentials.LinuxUsername
 		$this.VmPassword = $azureConfig.TestCredentials.LinuxPassword
-
 		# global variables: StorageAccount, TestLocation
 		if ( $this.StorageAccount -imatch "ExistingStorage_Standard" )
 		{

--- a/UnitTests/PowerShell/TestControllers/AzureController.Tests.ps1
+++ b/UnitTests/PowerShell/TestControllers/AzureController.Tests.ps1
@@ -1,0 +1,137 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache License.
+#
+
+using Module "..\..\..\TestControllers\AzureController.psm1"
+
+$moduleName = "AzureController"
+
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+$logModulePath = Join-Path $here "../../../Libraries/TestLogs.psm1"
+$helpersModulePath = Join-Path $here "../../../Libraries/TestHelpers.psm1"
+$azureModulePath = Join-Path $here "../../../Libraries/Azure.psm1"
+Import-Module $logModulePath -Force -DisableNameChecking
+Import-Module $helpersModulePath -Force -DisableNameChecking
+Import-Module $azureModulePath -Force -DisableNameChecking
+
+function Select-AzureRmSubscription {
+	param($SubscriptionId)
+	return
+}
+
+Describe "Test if module ${moduleName} ParseAndValidateParameters is valid" {
+	It "Should validate parameters" {
+		Mock Write-LogInfo -Verifiable -ModuleName $moduleName { return }
+
+		$azureController = New-Object -TypeName $moduleName
+		$fakeParams = @{
+			"RGIdentifier" = "fakeRG";
+			"ARMImageName" = "one two three four";
+			"TestLocation" = "fakeLocation";
+		}
+
+		{ $azureController.ParseAndValidateParameters($fakeParams) } | Should Not Throw
+	}
+
+	It "Should not validate parameters" {
+		Mock Write-LogErr -Verifiable -ModuleName $moduleName { return }
+
+		$azureController = New-Object -TypeName $moduleName
+		$fakeParams = @{
+			"RGIdentifier" = "";
+			"ARMImageName" = "one two three";
+			"TestLocation" = "";
+		}
+
+		{ $azureController.ParseAndValidateParameters($fakeParams) } | Should Throw
+	}
+
+	It "Should run all mocked commands" {
+		Assert-VerifiableMock
+	}
+}
+
+Describe "Test if module ${moduleName} SetGlobalVariables is valid" {
+	It "Should set global variables" {
+		Mock Set-Variable -Verifiable -ModuleName $moduleName { return }
+
+		$azureController = New-Object -TypeName $moduleName
+
+		{ $azureController.SetGlobalVariables() } | Should Not Throw
+	}
+
+	It "Should run all mocked commands" {
+		Assert-VerifiableMock
+	}
+}
+
+Describe "Test if module ${moduleName} PrepareTestEnvironment is valid" {
+	It "Should prepare test env" {
+
+		Mock Set-Variable -Verifiable -ModuleName $moduleName { return }
+		Mock Add-AzureAccountFromSecretsFile -Verifiable -ModuleName $moduleName { return }
+		Mock Write-LogErr -Verifiable -ModuleName "TestController" { return }
+		Mock Write-LogInfo -Verifiable -ModuleName $moduleName { return }
+		Mock Resolve-Path -Verifiable -ModuleName "TestController" {
+			$fakeXML = Join-Path $env:temp "test.xml"
+			New-Item -Type File -Path $fakeXML -Force | Out-Null;
+			@'
+			<Global>
+				<Azure>
+					<Subscription>
+						<SubscriptionID>test</SubscriptionID>
+						<ARMStorageAccount>ARMStorageAccount</ARMStorageAccount>
+					</Subscription>
+				</Azure>
+			</Global>
+'@ | Add-Content -Path $fakeXML
+			return $fakeXML
+		}
+		Mock Get-LISAv2Tools -Verifiable -ModuleName "TestController" { return }
+		Mock Select-AzureRmSubscription -Verifiable -ModuleName $moduleName {
+			return @{
+				"Account" = @{
+					"Id" = "Id"
+				};
+				"Subscription" = @{
+					"SubscriptionId" = "SubscriptionId";
+					"ARMStorageAccount" = "ARMStorageAccount";
+					"Name" = "SubscriptionId"
+				}
+			}
+		}
+
+		$azureController = New-Object -TypeName $moduleName
+		$azureController.TestLocation = "westus2"
+		$fakeXML = "test1.xml"
+
+		{ $azureController.PrepareTestEnvironment($fakeXML) } | Should Not Throw
+	}
+}
+
+Describe "Test if module ${moduleName} PrepareTestEnvironment can fail" {
+	It "Should fail to prepare test env" {
+		Mock Write-LogErr -Verifiable -ModuleName "TestController" { return }
+
+		$azureController = New-Object -TypeName $moduleName
+
+		$fakeXML = "test2.xml"
+		{ $azureController.PrepareTestEnvironment($fakeXML) } | Should Throw
+	}
+
+	It "Should run all mocked commands" {
+		Assert-VerifiableMock
+	}
+}
+
+Describe "Test if module ${moduleName} PrepareTestImage is valid" {
+	It "Should set prepare test image" {
+		$azureController = New-Object -TypeName $moduleName
+
+		{ $azureController.PrepareTestImage() } | Should Not Throw
+	}
+
+	It "Should run all mocked commands" {
+		Assert-VerifiableMock
+	}
+}

--- a/Utilities/AddAzureRmAccountFromSecretsFile.ps1
+++ b/Utilities/AddAzureRmAccountFromSecretsFile.ps1
@@ -40,44 +40,4 @@ Get-ChildItem (Join-Path $rootPath "Libraries") -Recurse | `
     Where-Object { $_.FullName.EndsWith(".psm1") } | `
     ForEach-Object { Import-Module $_.FullName -Force -Global -DisableNameChecking }
 
-if ( $customSecretsFilePath ) {
-    $secretsFile = $customSecretsFilePath
-    Write-LogInfo "Using provided secrets file: $secretsFile"
-}
-if ($env:Azure_Secrets_File) {
-    $secretsFile = $env:Azure_Secrets_File
-    Write-LogInfo "Using secrets file: $secretsFile, defined in environments."
-}
-if ( ($null -eq $secretsFile) -or ($secretsFile -eq [string]::Empty)) {
-    Write-LogErr "ERROR: The Secrets file is not being set."
-    Raise-Exception ("XML Secrets file not provided")
-}
-
-#---------------------------------------------------------[Script Start]--------------------------------------------------------
-
-if ( Test-Path $secretsFile ) {
-    Write-LogInfo "$secretsFile found."
-    Write-LogInfo "------------------------------------------------------------------"
-    Write-LogInfo "Authenticating Azure PS session.."
-    $XmlSecrets = [xml](Get-Content $secretsFile)
-    $ClientID = $XmlSecrets.secrets.SubscriptionServicePrincipalClientID
-    $TenantID = $XmlSecrets.secrets.SubscriptionServicePrincipalTenantID
-    $Key = $XmlSecrets.secrets.SubscriptionServicePrincipalKey
-    $pass = ConvertTo-SecureString $key -AsPlainText -Force
-    $mycred = New-Object System.Management.Automation.PSCredential ($ClientID, $pass)
-    $subIDSplitted = ($XmlSecrets.secrets.SubscriptionID).Split("-")
-    $subIDMasked = "$($subIDSplitted[0])-xxxx-xxxx-xxxx-$($subIDSplitted[4])"
-
-    $null = Add-AzureRmAccount -ServicePrincipal -Tenant $TenantID -Credential $mycred
-    $selectedSubscription = Select-AzureRmSubscription -SubscriptionId $XmlSecrets.secrets.SubscriptionID
-    if ( $selectedSubscription.Subscription.Id -eq $XmlSecrets.secrets.SubscriptionID ) {
-        Write-LogInfo "Current Subscription : $subIDMasked."
-    } else {
-        Write-LogInfo "There was an error when selecting $subIDMasked."
-    }
-    Write-LogInfo "------------------------------------------------------------------"
-}
-else {
-    Write-LogErr "Secret file $secretsFile does not exist"
-    Raise-Exception ("XML Secrets file not provided")
-}
+Add-AzureAccountFromSecretsFile -CustomSecretsFilePath $customSecretsFilePath


### PR DESCRIPTION
This PR adds Azure Controller unit tests and moves the Utilities/AddAzureRmAccountFromSecretsFile.ps1 logic to Libraries/Azure.psm1 so that it can be properly tested.