### PR TITLE
log: do not show non error/warning kernel logs in the lisav2 output

### DIFF
--- a/Libraries/CommonFunctions.psm1
+++ b/Libraries/CommonFunctions.psm1
@@ -957,10 +957,12 @@ Function Detect-LinuxDistro() {
 		# Instead of throw, it sets 'Unknown' if it does not exist
 		$CleanedDistroName = "Unknown"
 	} else {
-		$CleanedDistroName = $DistroName
+		# Note(v-advlad): DistroName must be cleaned of unwanted sudo output
+		# like 'sudo: unable to resolve host'
+		$CleanedDistroName = $DistroName.Split("`r`n").Trim() | Select-Object -Last 1
 		Set-Variable -Name detectedDistro -Value $CleanedDistroName -Scope Global
 		Set-DistroSpecificVariables -detectedDistro $detectedDistro
-		Write-LogInfo "Linux distro detected : $CleanedDistroName"
+		Write-LogInfo "Linux distro detected: $CleanedDistroName"
 	}
 
 	return $CleanedDistroName


### PR DESCRIPTION
Do not show all kernel logs in lisav2 output, as it makes the reading of the logs very hard.

Also sanitize the distro name in case unwanted output like "sudo: unable to resolve host" appears.

Partially fixes: https://github.com/LIS/LISAv2/issues/590

Execution tested:

```
Test Run On           : 01/16/2019 19:39:10
ARM Image Under Test  : Canonical : UbuntuServer : 18.04-DAILY-LTS : latest
Total Test Cases      : 1 (1 Pass, 0 Fail, 0 Abort)
Total Time (dd:hh:mm) : 0:0:5

   ID TestCaseName                                                                TestResult TestDuration(in minutes)
---------------------------------------------------------------------------------------------------------------------
    1 BVT-CORE-VERIFY-LIS-MODULES                                                       PASS                 2.44

```


```
[LISAv2 Test Results Summary]
Test Run On           : 01/16/2019 19:46:50
VHD Under Test        : Virtual Hard Disks\1604.vhdx
Total Test Cases      : 1 (1 Pass, 0 Fail, 0 Abort)
Total Time (dd:hh:mm) : 0:0:2

   ID TestCaseName                                                                TestResult TestDuration(in minutes)
---------------------------------------------------------------------------------------------------------------------
    1 BVT-CORE-VERIFY-LIS-MODULES                                                       PASS                  0.9
```
