### PR TITLE
framework: Wrong InternalIP in $AllVMData

### DIFF
--- a/Libraries/Azure.psm1
+++ b/Libraries/Azure.psm1
@@ -659,11 +659,11 @@ Function Get-AllDeploymentData($ResourceGroups)
 
 			foreach ( $nic in $NICdata )
 			{
-				if (( $nic.Name -imatch $testVM.ResourceName) -and ( $nic.Name -imatch "PrimaryNIC"))
+				if (($nic.Name.Replace("PrimaryNIC-","") -eq $testVM.ResourceName) -and ( $nic.Name -imatch "PrimaryNIC"))
 				{
 					$QuickVMNode.InternalIP = "$($nic.Properties.IpConfigurations[0].Properties.PrivateIPAddress)"
 				}
-				if (( $nic.Name -imatch $testVM.ResourceName) -and ( $nic.Name -imatch "ExtraNetworkCard-1"))
+				if (($nic.Name.Replace("ExtraNetworkCard-1-","") -eq $testVM.ResourceName) -and ($nic.Name -imatch "ExtraNetworkCard-1"))
 				{
 					$QuickVMNode.SecondInternalIP = "$($nic.Properties.IpConfigurations[0].Properties.PrivateIPAddress)"
 				}


### PR DESCRIPTION
The framework didn't put InternalIP correctly. In case we had multiple VMs (over 10), then the 'imatch' would match VMs with double digits (e.g. client-10, client-11,) with the single digits one (e.g. with
client-1). That is breaking AllVMData since the Private IPs that are put there are not matching the VMs.
This is solving https://github.com/LIS/LISAv2/issues/613.

Since it's a framework change, **do not rush to merge** it until we have an approval for every requested reviewer.