### PR TITLE
Replace deprecated ifconfig with iproute2 - ip commands

### DIFF
--- a/Libraries/CommonFunctions.psm1
+++ b/Libraries/CommonFunctions.psm1
@@ -851,30 +851,24 @@ function Enable-SRIOVInAllVMs($allVMData, $TestProvider)
 				$vmCount += 1
 				if ($sriovOutput -imatch "DATAPATH_SWITCHED_TO_VF")
 				{
-					$AfterIfConfigStatus = $null
-					$AfterIfConfigStatus = Run-LinuxCmd -ip $vmData.PublicIP -port $vmData.SSHPort -username $user -password $password -command "dmesg" -runMaxAllowedTime 30 -runAsSudo
-					if ($AfterIfConfigStatus -imatch "Data path switched to VF")
+					$AfterInterfaceStatus = $null
+					$AfterInterfaceStatus = Run-LinuxCmd -ip $vmData.PublicIP -port $vmData.SSHPort -username $user -password $password -command "dmesg" -runMaxAllowedTime 30 -runAsSudo
+					if ($AfterInterfaceStatus -imatch "Data path switched to VF")
 					{
 						Write-LogInfo "Data path already switched to VF in $($vmData.RoleName)"
 						$bondSuccess += 1
-					}
-					else
-					{
+					} else {
 						Write-LogErr "Data path not switched to VF in $($vmData.RoleName)"
 						$bondError += 1
 					}
-				}
-				else
-				{
-					$AfterIfConfigStatus = $null
-					$AfterIfConfigStatus = Run-LinuxCmd -ip $vmData.PublicIP -port $vmData.SSHPort -username $user -password $password -command "/sbin/ifconfig -a" -runAsSudo
-					if ($AfterIfConfigStatus -imatch "bond")
+				} else {
+					$AfterInterfaceStatus = $null
+					$AfterInterfaceStatus = Run-LinuxCmd -ip $vmData.PublicIP -port $vmData.SSHPort -username $user -password $password -command "ip addr show" -runAsSudo
+					if ($AfterInterfaceStatus -imatch "bond")
 					{
 						Write-LogInfo "New bond detected in $($vmData.RoleName)"
 						$bondSuccess += 1
-					}
-					else
-					{
+					} else {
 						Write-LogErr "New bond not detected in $($vmData.RoleName)"
 						$bondError += 1
 					}

--- a/Testscripts/Linux/BVT-CORE-RELOAD-MODULES.sh
+++ b/Testscripts/Linux/BVT-CORE-RELOAD-MODULES.sh
@@ -159,8 +159,9 @@ END=$(date +%s)
 DIFF=$(echo "$END - $START" | bc)
 
 LogMsg "Info: Finished testing, bringing up eth0"
-ifdown eth0
-ifup eth0
+ip link set eth0 down
+ip link set eth0 up
+
 if ! dhclient
 then
     msg="Error: dhclient exited with an error"
@@ -169,15 +170,15 @@ then
     exit 0
 fi
 VerifyModules
-ipAddress=$(ifconfig | grep 'inet addr:' | grep -v '127.0.0.1' | cut -d: -f2 | cut -d' ' -f1 | sed -n 1p)
-if [[ ${ipAddress} -eq '' ]]; then
+
+ipAddress=$(ip addr show eth0 | grep "inet\b")
+if [ -z "$ipAddress" ]; then
     LogMsg "Info: Waiting for interface to receive an IP"
     sleep 30
 fi
 
 LogMsg "Info: Test ran for ${DIFF} seconds"
 
-LogMsg "#########################################################"
 LogMsg "Result : Test Completed Successfully"
 LogMsg "Exiting with state: TestCompleted."
 SetTestStateCompleted

--- a/Testscripts/Linux/NET-Multicast.sh
+++ b/Testscripts/Linux/NET-Multicast.sh
@@ -52,7 +52,7 @@ if [ $? -ne 0 ];then
 fi
 
 # Configure VM1
-ifconfig $test_iface allmulti
+ip link set dev $test_iface allmulticast on
 if [ $? -ne 0 ]; then
     LogMsg "Could not enable ALLMULTI on VM1"
     SetTestStateAborted
@@ -60,7 +60,7 @@ if [ $? -ne 0 ]; then
 fi
 
 # Configure VM2
-Execute_Validate_Remote_Command "ifconfig $test_iface allmulti"
+Execute_Validate_Remote_Command "ip link set dev $test_iface allmulticast on"
 Execute_Validate_Remote_Command "echo '1' > /proc/sys/net/ipv4/ip_forward"
 Execute_Validate_Remote_Command "ip route add 224.0.0.0/4 dev $test_iface"
 Execute_Validate_Remote_Command "echo '0' > /proc/sys/net/ipv4/icmp_echo_ignore_broadcasts"
@@ -76,7 +76,7 @@ fi
 
 LogMsg "ping was started on both VMs. Results will be checked in a few seconds"
 sleep 5
- 
+
 # Check results - Summary must show a 0% loss of packets
 multicastSummary=$(cat out.client | grep 0%)
 if [ $? -ne 0 ]; then

--- a/Testscripts/Linux/NET-Verify-HotAdd-MultiNIC.sh
+++ b/Testscripts/Linux/NET-Verify-HotAdd-MultiNIC.sh
@@ -52,7 +52,6 @@ function Add_Nic {
     sleep 5
     # Verify the new NIC received an IP v4 address
     LogMsg "Verify the new NIC has an IPv4 address"
-    #ifconfig ${eth_name} | grep -s "inet " > /dev/null
     ip addr show ${eth_name} | grep "inet\b" > /dev/null
     check_exit_status "${eth_name} is up"  "exit"
 }

--- a/Testscripts/Linux/TestRDMA_MultiVM.sh
+++ b/Testscripts/Linux/TestRDMA_MultiVM.sh
@@ -88,9 +88,9 @@ total_virtual_machines=0
 slaves_array=$(echo ${slaves} | tr ',' ' ')
 for vm in $master $slaves_array; do
 	LogMsg "Checking $ib_nic status in $vm"
-	temp=$(ssh root@${vm} "ifconfig $ib_nic | grep 'inet '")
+	temp=$(ssh root@${vm} "ip addr show $ib_nic | grep 'inet\b'")
 	ib_nic_status=$?
-	ssh root@${vm} "ifconfig $ib_nic > $ib_nic-status-${vm}.txt"
+	ssh root@${vm} "ip -o addr show $ib_nic > $ib_nic-status-${vm}.txt"
 	scp root@${vm}:${ib_nic}-status-${vm}.txt .
 	if [ $ib_nic_status -eq 0 ]; then
 		LogMsg "${ib_nic} IP detected for ${vm}."

--- a/Testscripts/Linux/nested_hyperv_ntttcp_different_l1_public_bridge.sh
+++ b/Testscripts/Linux/nested_hyperv_ntttcp_different_l1_public_bridge.sh
@@ -87,13 +87,14 @@ Start_Test()
     echo "client=$CLIENT_IP_ADDR" >> ${CONSTANTS_FILE}
     echo "nicName=$NIC_NAME" >> ${CONSTANTS_FILE}
 
-    echo $NestedUserPassword | sudo -S ifconfig $NIC_NAME up $IP_ADDR netmask 255.255.255.0 up
+    echo $NestedUserPassword | sudo -S ip addr add $IP_ADDR/24 dev $NIC_NAME
+    echo $NestedUserPassword | sudo -S ip link set $NIC_NAME up
     check_exit_status "Setup static IP address for $NIC_NAME"
     chmod a+x /home/$NestedUser/*.sh
 
     Log_Msg "Enable root for VM $role" $log_file
     echo $NestedUserPassword | sudo -S /home/$NestedUser/enableRoot.sh -password $NestedUserPassword
-    echo $NestedUserPassword | sudo -S cp /home/$NestedUser/*.sh /root 
+    echo $NestedUserPassword | sudo -S cp /home/$NestedUser/*.sh /root
     remote_exec -host localhost -user root -passwd $NestedUserPassword -port 22 "hostname"
 
     if [ "$role" == "server" ]; then

--- a/Testscripts/Linux/nested_kvm_lagscope_different_l1_public_bridge.sh
+++ b/Testscripts/Linux/nested_kvm_lagscope_different_l1_public_bridge.sh
@@ -176,7 +176,7 @@ Prepare_Nested_VMs()
         Prepare_Client
     fi
     Reboot_Nested_VM -user "root" -passwd $NestedUserPassword -port $HOST_FWD_PORT
-    Remote_Exec_Wrapper "root" $HOST_FWD_PORT "ifconfig $NIC_NAME $IP_ADDR netmask 255.255.255.0 up"
+    Remote_Exec_Wrapper "root" $HOST_FWD_PORT "ip addr add $IP_ADDR/24 dev $NIC_NAME && ip link set $NIC_NAME up"
 }
 
 Run_Lagscope_On_Client()

--- a/Testscripts/Linux/nested_kvm_netperf_pps.sh
+++ b/Testscripts/Linux/nested_kvm_netperf_pps.sh
@@ -181,7 +181,7 @@ Prepare_Nested_VMs()
         Prepare_Client
     fi
     Reboot_Nested_VM -user "root" -passwd $NestedUserPassword -port $HOST_FWD_PORT
-    Remote_Exec_Wrapper "root" $HOST_FWD_PORT "ifconfig $NIC_NAME $IP_ADDR netmask 255.255.255.0 up"
+    Remote_Exec_Wrapper "root" $HOST_FWD_PORT "ip addr add $IP_ADDR/24 dev $NIC_NAME && ip link set $NIC_NAME up"
 }
 
 Run_Netperf_On_Client()

--- a/Testscripts/Linux/nested_kvm_ntttcp_different_l1_nat.sh
+++ b/Testscripts/Linux/nested_kvm_ntttcp_different_l1_nat.sh
@@ -128,9 +128,10 @@ fi
 Setup_Network()
 {
     Log_Msg "Setup network" $log_file
-    ifconfig eth1 $IP_ADDR netmask 255.255.255.0 up
+    ip addr add $IP_ADDR/24 dev eth1
+    ip link set eth1 up
     check_exit_status "Setup network"
-    ./nat_qemu_ifup.sh 
+    ./nat_qemu_ifup.sh
 }
 
 Start_Nested_VM_Nat()

--- a/Testscripts/Linux/nested_kvm_ntttcp_different_l1_public_bridge.sh
+++ b/Testscripts/Linux/nested_kvm_ntttcp_different_l1_public_bridge.sh
@@ -182,7 +182,7 @@ Prepare_Nested_VMs()
         Prepare_Client
     fi
     Reboot_Nested_VM -user "root" -passwd $NestedUserPassword -port $HOST_FWD_PORT
-    Remote_Exec_Wrapper "root" $HOST_FWD_PORT "ifconfig $NIC_NAME $IP_ADDR netmask 255.255.255.0 up"
+    Remote_Exec_Wrapper "root" $HOST_FWD_PORT "ip addr add $IP_ADDR/24 dev $NIC_NAME && ip link set $NIC_NAME up"
 }
 
 Run_Ntttcp_On_Client()

--- a/Testscripts/Linux/nested_kvm_ntttcp_private_bridge.sh
+++ b/Testscripts/Linux/nested_kvm_ntttcp_private_bridge.sh
@@ -102,8 +102,9 @@ Setup_Bridge() {
 		return
 	fi
 	Log_Msg "Setting up bridge $BR_NAME" $log_file
-	ip link add $BR_NAME type bridge
-	ifconfig $BR_NAME $BR_ADDR netmask 255.255.255.0 up
+	ip link add "$BR_NAME" type bridge
+	ip addr add "$BR_ADDR"/24 dev "$BR_NAME"
+	ip link set "$BR_NAME" up
 	check_exit_status "Setup bridge $BR_NAME"
 }
 
@@ -192,7 +193,7 @@ Bring_Up_Nic_With_Private_Ip() {
 		else
 			sleep 10
 			Log_Msg "Try to bring up the nested VM NIC with private IP, left retry times: $retry_times" $log_file
-			Remote_Exec_Wrapper "root" $host_fwd_port "ifconfig $NIC_NAME $ip_addr netmask 255.255.255.0 up"
+			Remote_Exec_Wrapper "root" $host_fwd_port "ip addr add $ip_addr/24 dev $NIC_NAME && ip link set $NIC_NAME up"
 			exit_status=$?
 		fi
 	done

--- a/Testscripts/Linux/nested_vm_utils.sh
+++ b/Testscripts/Linux/nested_vm_utils.sh
@@ -237,7 +237,8 @@ Setup_Public_Bridge() {
     ip link add $br_name type bridge
     ip link set dev $br_name up
     ip link set dev eth1 master $br_name
-    ifconfig $br_name $br_addr netmask 255.255.255.0 up
+    ip addr add $br_addr/24 dev $br_name
+    ip link set $br_name up
 }
 
 Setup_Tap() {

--- a/Testscripts/Linux/restart-interface-reload-netvsc.sh
+++ b/Testscripts/Linux/restart-interface-reload-netvsc.sh
@@ -6,14 +6,7 @@
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
-#
-#
-# Sample script to run sysbench.
-# In this script, we want to bench-mark device IO performance on a mounted folder.
-# You can adapt this script to other situations easily like for stripe disks as RAID0.
-# The only thing to keep in mind is that each different configuration you're testing
-# must log its output to a different directory.
-#
+
 # Source utils.sh
 . utils.sh || {
     echo "ERROR: unable to source utils.sh!"
@@ -45,7 +38,7 @@ Run()
 }
 
 ############################################################
-#       Main body
+# Main body
 ############################################################
 config_path="/boot/config-$(uname -r)"
 netvsc_includes=`grep CONFIG_HYPERV_NET=y $config_path`
@@ -71,10 +64,10 @@ while [[ $TestCount -lt $TestIterations ]];
 do
     TestCount=$(( TestCount + 1 ))
     LogMsg "Test Iteration : $TestCount"
-    Run "ifdown $NetworkInterface"
+    Run "ip link set $NetworkInterface down"
     if [[ "$?" == "0" ]];
     then
-        LogMsg "ifdown $NetworkInterface : SUCCESS"
+        LogMsg "Bringing down interface $NetworkInterface : SUCCESS"
         Run 'rmmod hv_netvsc'
         if [[ "$?" == "0" ]];
         then
@@ -83,24 +76,24 @@ do
             if [[ "$?" == "0" ]];
             then
                 LogMsg "modprobe hv_netvsc : SUCCESS"
-                Run "ifup $NetworkInterface"
+                Run "ip link set $NetworkInterface up"
                 if [[ "$?" == "0" ]];
                 then
-                        LogMsg "ifup $NetworkInterface : SUCCESS"
+                        LogMsg "Bringing up interface $NetworkInterface : SUCCESS"
                 else
-                        LogMsg "ifup $NetworkInterface : Failed."
+                        LogMsg "Bringing up interface $NetworkInterface : Failed."
                         ExitCode=$(( ExitCode + 1 ))
-                fi                          
+                fi
             else
                 LogMsg "modprobe hv_netvsc : Failed."
                 ExitCode=$(( ExitCode + 1 ))
-            fi                  
+            fi
         else
             LogMsg "rmmod hv_netvsc : Failed."
             ExitCode=$(( ExitCode + 1 ))
         fi
     else
-        LogMsg "ifdown $NetworkInterface : Failed."
+        LogMsg "Bringing down interface $NetworkInterface : Failed."
         ExitCode=$(( ExitCode + 1 ))
     fi
     LogMsg "Sleeping 5 seconds"

--- a/Testscripts/Linux/utils.sh
+++ b/Testscripts/Linux/utils.sh
@@ -6,9 +6,9 @@
 #
 # Description:
 #
-# This script contains all distro-specific functions, as well as 
+# This script contains all distro-specific functions, as well as
 # other common functions used in the LISAv2 test scripts.
-# Private variables used in scripts should use the __VAR_NAME notation. 
+# Private variables used in scripts should use the __VAR_NAME notation.
 # Using the bash built-in `declare' statement also restricts the variable's scope.
 # Same for "private" functions.
 #
@@ -373,12 +373,12 @@ CheckVMFeatureSupportStatus()
 }
 
 # Function to get all synthetic network interfaces
-# Sets the $SYNTH_NET_INTERFACES array elements to an interface name suitable for ifconfig etc.
+# Sets the $SYNTH_NET_INTERFACES array elements to an interface name suitable for network tools use
 # Takes no arguments
 GetSynthNetInterfaces()
 {
-	#Check for distribuion version
-	case $DISTRO in
+    # Check for distribuion version
+    case $DISTRO in
         redhat_5)
             check="net:*"
             ;;
@@ -395,7 +395,7 @@ GetSynthNetInterfaces()
         *)
              SYNTH_NET_INTERFACES[$1]=$(ls "${__SYNTH_NET_ADAPTERS_PATHS[$1]}" | head -n 1)
             ;;
-    	esac
+        esac
     }
 
 
@@ -438,11 +438,10 @@ GetSynthNetInterfaces()
 }
 
 # Function to get all legacy network interfaces
-# Sets the $LEGACY_NET_INTERFACES array elements to an interface name suitable for ifconfig/ip commands.
+# Sets the $LEGACY_NET_INTERFACES array elements to an interface name suitable for network tools use
 # Takes no arguments
 GetLegacyNetInterfaces()
 {
-
 	# declare array
 	declare -a __LEGACY_NET_ADAPTERS_PATHS
 	# Add legacy netadapter paths into __LEGACY_NET_ADAPTERS_PATHS array
@@ -629,7 +628,7 @@ SetIPstatic()
 	__ip="$1"
 
 	echo "$__netmask" | grep '.' >/dev/null 2>&1
-	if [  0 -eq $? ]; then
+	if [ 0 -eq $? ]; then
 		__netmask=$(NetmaskToCidr "$__netmask")
 		if [ 0 -ne $? ]; then
 			LogMsg "SetIPstatic: $__netmask is not a valid netmask"
@@ -836,9 +835,8 @@ CreateVlanConfig()
 	fi
 
 	# check that vlan driver is loaded
-	lsmod | grep 8021q
-
-	if [ 0 -ne $? ]; then
+	if ! lsmod | grep 8021q
+	then
 		modprobe 8021q
 	fi
 
@@ -854,71 +852,37 @@ CreateVlanConfig()
 	__netmask="$3"
 	__vlanID="$4"
 
+	# consider a better cleanup of environment if an existing interfaces setup exists
+	__file_path="/etc/sysconfig/network-scripts/ifcfg-$__interface"
+	if [ -e "$__file_path" ]; then
+		LogMsg "CreateVlanConfig: warning, $__file_path already exists."
+		if [ -d "$__file_path" ]; then
+			rm -rf "$__file_path"
+		else
+			rm -f "$__file_path"
+		fi
+	fi
+
+	__vlan_file_path="/etc/sysconfig/network-scripts/ifcfg-$__interface.$__vlanID"
+	if [ -e "$__vlan_file_path" ]; then
+		LogMsg "CreateVlanConfig: warning, $__vlan_file_path already exists."
+		if [ -d "$__vlan_file_path" ]; then
+			rm -rf "$__vlan_file_path"
+		else
+			rm -f "$__vlan_file_path"
+		fi
+	fi
+
 	GetDistro
 	case $DISTRO in
-		redhat*|centos*|fedora*)
-			__file_path="/etc/sysconfig/network-scripts/ifcfg-$__interface"
-			if [ -e "$__file_path" ]; then
-				LogMsg "CreateVlanConfig: warning, $__file_path already exists."
-				if [ -d "$__file_path" ]; then
-					rm -rf "$__file_path"
-				else
-					rm -f "$__file_path"
-				fi
-			fi
-
-			__vlan_file_path="/etc/sysconfig/network-scripts/ifcfg-$__interface.$__vlanID"
-			if [ -e "$__vlan_file_path" ]; then
-				LogMsg "CreateVlanConfig: warning, $__vlan_file_path already exists."
-				if [ -d "$__vlan_file_path" ]; then
-					rm -rf "$__vlan_file_path"
-				else
-					rm -f "$__vlan_file_path"
-				fi
-			fi
-
-			cat <<-EOF > "$__file_path"
-				DEVICE=$__interface
-				TYPE=Ethernet
-				BOOTPROTO=none
-				ONBOOT=yes
-			EOF
-
-			cat <<-EOF > "$__vlan_file_path"
-				DEVICE=$__interface.$__vlanID
-				BOOTPROTO=none
-				$ipAddress=$__ip
-				$netmaskConf=$__netmask
-				ONBOOT=yes
-				VLAN=yes
-			EOF
-
-			ifdown "$__interface"
-			ifup "$__interface"
-			ifup "$__interface.$__vlanID"
+		redhat*|centos*|fedora*|debian*|ubuntu*)
+			ip link add link "$__interface" name "$__interface.$__vlanID" type vlan id "$__vlanID"
+			ip addr add "$__ip/$__netmask" dev "$__interface.$__vlanID"
+			ip link set dev "$__interface" up
+			ip link set dev "$__interface.$__vlanID" up
 
 			;;
 		suse_12*)
-			__file_path="/etc/sysconfig/network/ifcfg-$__interface"
-			if [ -e "$__file_path" ]; then
-				LogMsg "CreateVlanConfig: warning, $__file_path already exists."
-				if [ -d "$__file_path" ]; then
-					rm -rf "$__file_path"
-				else
-					rm -f "$__file_path"
-				fi
-			fi
-
-			__vlan_file_path="/etc/sysconfig/network/ifcfg-$__interface.$__vlanID"
-			if [ -e "$__vlan_file_path" ]; then
-				LogMsg "CreateVlanConfig: warning, $__vlan_file_path already exists."
-				if [ -d "$__vlan_file_path" ]; then
-					rm -rf "$__vlan_file_path"
-				else
-					rm -f "$__vlan_file_path"
-				fi
-			fi
-
 			cat <<-EOF > "$__file_path"
 				TYPE=Ethernet
 				BOOTPROTO=none
@@ -944,34 +908,14 @@ CreateVlanConfig()
 				EOF
 			fi
 
-
 			# bring real interface down and up again
 			wicked ifdown "$__interface"
 			wicked ifup "$__interface"
 			# bring also vlan interface up
 			wicked ifup "$__interface.$__vlanID"
+
 			;;
 		suse*)
-			__file_path="/etc/sysconfig/network/ifcfg-$__interface"
-			if [ -e "$__file_path" ]; then
-				LogMsg "CreateVlanConfig: warning, $__file_path already exists."
-				if [ -d "$__file_path" ]; then
-					rm -rf "$__file_path"
-				else
-					rm -f "$__file_path"
-				fi
-			fi
-
-			__vlan_file_path="/etc/sysconfig/network/ifcfg-$__interface.$__vlanID"
-			if [ -e "$__vlan_file_path" ]; then
-				LogMsg "CreateVlanConfig: warning, $__vlan_file_path already exists."
-				if [ -d "$__vlan_file_path" ]; then
-					rm -rf "$__vlan_file_path"
-				else
-					rm -f "$__vlan_file_path"
-				fi
-			fi
-
 			cat <<-EOF > "$__file_path"
 				BOOTPROTO=static
 				IPADDR=0.0.0.0
@@ -997,96 +941,10 @@ CreateVlanConfig()
 				EOF
 			fi
 
-			ifdown "$__interface"
-			ifup "$__interface"
-			ifup "$__interface.$__vlanID"
-			;;
-		debian*|ubuntu*)
-			#Check for vlan package and install it in case of absence
-			dpkg -s vlan
-			if [ 0 -ne $? ]; then
-				apt -y install vlan
-				if [ 0 -ne $? ]; then
-					LogMsg "Failed to install VLAN package. Please try manually."
-					return 90
-				fi
-			fi
-			__file_path="/etc/network/interfaces"
-			if [ ! -e "$__file_path" ]; then
-				LogMsg "CreateVlanConfig: warning, $__file_path does not exist. Creating it..."
-				if [ -d "$(dirname $__file_path)" ]; then
-					touch "$__file_path"
-				else
-					rm -f "$(dirname $__file_path)"
-					LogMsg "CreateVlanConfig: Warning $(dirname $__file_path) is not a directory"
-					mkdir -p "$(dirname $__file_path)"
-					touch "$__file_path"
-				fi
-			fi
+			ip link set "$__interface" down
+			ip link set "$__interface" up
+			ip link set "$__interface.$__vlanID" up
 
-			declare __first_iface
-			declare __last_line
-			declare __second_iface
-			# delete any previously existing lines containing the desired vlan interface
-			# get first line number containing our interested interface
-			__first_iface=$(awk "/iface $__interface/ { print NR; exit }" "$__file_path")
-			# if there was any such line found, delete it and any related config lines
-			if [ -n "$__first_iface" ]; then
-				# get the last line of the file
-				__last_line=$(wc -l $__file_path | cut -d ' ' -f 1)
-				# sanity check
-				if [ "$__first_iface" -gt "$__last_line" ]; then
-					LogMsg "CreateVlanConfig: error while parsing $__file_path . First iface line is gt last line in file"
-					return 100
-				fi
-
-				# get the last x lines after __first_iface
-				__second_iface=$((__last_line-__first_iface))
-
-				# if the first_iface was also the last line in the file
-				if [ "$__second_iface" -eq 0 ]; then
-					__second_iface=$__last_line
-				else
-					# get the line number of the seconf iface line
-					__second_iface=$(tail -n $__second_iface $__file_path | awk "/iface/ { print NR; exit }")
-
-					if [ -z $__second_iface ]; then
-						__second_iface="$__last_line"
-					else
-						__second_iface=$((__first_iface+__second_iface-1))
-					fi
-
-
-					if [ "$__second_iface" -gt "$__last_line" ]; then
-						LogMsg "CreateVlanConfig: error while parsing $__file_path . Second iface line is gt last line in file"
-						return 100
-					fi
-
-					if [ "$__second_iface" -le "$__first_iface" ]; then
-						LogMsg "CreateVlanConfig: error while parsing $__file_path . Second iface line is gt last line in file"
-						return 100
-					fi
-				fi
-				# now delete all lines between the first iface and the second iface
-				sed -i "$__first_iface,${__second_iface}d" "$__file_path"
-			fi
-
-			sed -i "/auto $__interface/d" "$__file_path"
-			# now append our config to the end of the file
-			cat << EOF >> "$__file_path"
-auto $__interface
-iface $__interface inet static
-	address 0.0.0.0
-
-auto $__interface.$__vlanID
-iface $__interface.$__vlanID $ifaceConf static
-	address $__ip
-	netmask $__netmask
-EOF
-
-			ifdown "$__interface"
-			ifup $__interface
-			ifup $__interface.$__vlanID
 			;;
 		*)
 			LogMsg "Platform not supported yet!"
@@ -1097,8 +955,7 @@ EOF
 	sleep 5
 
 	# verify change took place
-	cat /proc/net/vlan/config | grep " $__vlanID "
-
+	grep "$__vlanID" /proc/net/vlan/config
 	if [ 0 -ne $? ]; then
 		LogMsg "/proc/net/vlan/config has no vlanID of $__vlanID"
 		return 5
@@ -1183,9 +1040,9 @@ RemoveVlanConfig()
 				fi
 			fi
 
-			ifdown $__interface.$__vlanID
-			ifdown $__interface
-			ifup $__interface
+			ip link set "$__interface.$__vlanID" down
+			ip link set "$__interface" down
+			ip link set "$__interface" up
 
 			# make sure the interface is down
 			ip link set "$__interface.$__vlanID" down
@@ -1329,7 +1186,6 @@ CreateIfupConfigFile()
 
 				wicked ifdown "$__interface_name"
 				wicked ifup "$__interface_name"
-
 				;;
 			suse*)
 				__file_path="/etc/sysconfig/network/ifcfg-$__interface_name"
@@ -1347,11 +1203,10 @@ CreateIfupConfigFile()
 					BOOTPROTO=dhcp
 				EOF
 
-				ifdown "$__interface_name"
-				ifup "$__interface_name"
-
+				ip link set "$__interface_name" down
+				ip link set "$__interface_name" up
 				;;
-			redhat_7|redhat_8|centos_7|centos_8|fedora*)
+			redhat_6|centos_6|redhat_7|redhat_8|centos_7|centos_8|fedora*)
 				__file_path="/etc/sysconfig/network-scripts/ifcfg-$__interface_name"
 				if [ ! -d "$(dirname $__file_path)" ]; then
 					LogMsg "CreateIfupConfigFile: $(dirname $__file_path) does not exist! Something is wrong with the network config!"
@@ -1367,29 +1222,8 @@ CreateIfupConfigFile()
 					BOOTPROTO=dhcp
 				EOF
 
-				ifdown "$__interface_name"
-				ifup "$__interface_name"
-
-				;;
-			redhat_6|centos_6)
-				__file_path="/etc/sysconfig/network-scripts/ifcfg-$__interface_name"
-				if [ ! -d "$(dirname $__file_path)" ]; then
-					LogMsg "CreateIfupConfigFile: $(dirname $__file_path) does not exist! Something is wrong with the network config!"
-					return 3
-				fi
-
-				if [ -e "$__file_path" ]; then
-					LogMsg "CreateIfupConfigFile: Warning will overwrite $__file_path ."
-				fi
-
-				cat <<-EOF > "$__file_path"
-					DEVICE="$__interface_name"
-					BOOTPROTO=dhcp
-					IPV6INIT=yes
-				EOF
-
-				ifdown "$__interface_name"
-				ifup "$__interface_name"
+				ip link set "$__interface_name" up
+				service network restart || service networking restart
 
 				;;
 			redhat_5|centos_5)
@@ -1413,8 +1247,7 @@ CreateIfupConfigFile()
 					NETWORKING_IPV6=yes
 				EOF
 
-				ifdown "$__interface_name"
-				ifup "$__interface_name"
+				ip link set "$__interface_name" up
 
 				;;
 			debian*|ubuntu*)
@@ -1440,10 +1273,8 @@ CreateIfupConfigFile()
 					iface $__interface_name inet dhcp
 				EOF
 
-				service network-manager restart
-				ifdown "$__interface_name"
-				ifup "$__interface_name"
-
+				ip link set "$__interface_name" up
+				service networking restart || service network restart
 				;;
 			*)
 				LogMsg "CreateIfupConfigFile: Platform not supported yet!"
@@ -1525,8 +1356,8 @@ CreateIfupConfigFile()
 					NETMASK="$__netmask"
 				EOF
 
-				ifdown "$__interface_name"
-				ifup "$__interface_name"
+				ip link set "$__interface_name" down
+				ip link set "$__interface_name" up
 				;;
 			redhat*|centos*|fedora*)
 				__file_path="/etc/sysconfig/network-scripts/ifcfg-$__interface_name"
@@ -1558,8 +1389,8 @@ CreateIfupConfigFile()
 					EOF
 				fi
 
-				ifdown "$__interface_name"
-				ifup "$__interface_name"
+				ip link set "$__interface_name" up
+				service network restart || service networking restart
 				;;
 
 			debian*|ubuntu*)
@@ -1601,13 +1432,11 @@ CreateIfupConfigFile()
 					EOF
 				fi
 
-				service network-manager restart
-				ifdown "$__interface_name"
-				ifup "$__interface_name"
-
+				ip link set "$__interface_name" up
+				service networking restart || service network restart
 				;;
 			*)
-				LogMsg "CreateIfupConfigFile: Platform not supported yet!"
+				LogMsg "CreateIfupConfigFile: Platform not supported!"
 				return 3
 				;;
 		esac
@@ -1703,7 +1532,7 @@ ControlNetworkManager()
 			fi
 			;;
 		*)
-			LogMsg "Platform not supported yet!"
+			LogMsg "Platform not supported!"
 			return 3
 			;;
 	esac
@@ -1906,7 +1735,6 @@ TearDownBridge()
 # $2 number of bytes to compare
 # return == 0 if total free space is greater than $2
 # return 1 otherwise
-
 IsFreeSpace()
 {
 	if [ 2 -ne $# ]; then
@@ -2145,7 +1973,8 @@ VerifyIsEthtool()
                 fi
                 ;;
             ubuntu*|debian*)
-                apt install ethtool -y
+                apt update -y
+		apt install ethtool -y
                 if [ $? -ne 0 ]; then
                     msg="ERROR: Failed to install Ethtool"
                     LogMsg "$msg"
@@ -2635,7 +2464,8 @@ function install_iperf3 () {
 				echo "iface $nic_name inet6 auto" >> /etc/network/interfaces.d/50-cloud-init.cfg
 				echo "up sleep 5" >> /etc/network/interfaces.d/50-cloud-init.cfg
 				echo "up dhclient -1 -6 -cf /etc/dhcp/dhclient6.conf -lf /var/lib/dhcp/dhclient6.$nic_name.leases -v $nic_name || true" >> /etc/network/interfaces.d/50-cloud-init.cfg
-				ifdown $nic_name && ifup $nic_name
+				ip link set $nic_name down
+				ip link set $nic_name up
 			fi
 			;;
 
@@ -3119,8 +2949,8 @@ function collect_VM_properties () {
 	echo ",Total Memory,"`free -h|grep Mem|awk '{print $2}'` >> $output_file
 	echo ",Resource disks size,"`lsblk|grep "^sdb"| awk '{print $4}'`  >> $output_file
 	echo ",Data disks attached,"`lsblk | grep "^sd" | awk '{print $1}' | sort | grep -v "sd[ab]$" | wc -l`  >> $output_file
-	echo ",eth0 MTU,"`ifconfig eth0|grep MTU|sed "s/.*MTU:\(.*\) .*/\1/"` >> $output_file
-	echo ",eth1 MTU,"`ifconfig eth1|grep MTU|sed "s/.*MTU:\(.*\) .*/\1/"` >> $output_file
+	echo ",eth0 MTU,"`cat /sys/class/net/eth0/mtu` >> $output_file
+	echo ",eth1 MTU,"`cat /sys/class/net/eth1/mtu` >> $output_file
 }
 
 # Add command in startup files

--- a/Testscripts/Windows/NESTED-HYPERV-NTTTCP-DIFFERENT-L1-NAT.ps1
+++ b/Testscripts/Windows/NESTED-HYPERV-NTTTCP-DIFFERENT-L1-NAT.ps1
@@ -562,8 +562,12 @@ function Main () {
 		}
 
 		if($testPlatform -ne "Azure") {
-			Run-LinuxCmd -username $nestedUser -password $nestedPassword -ip $nttcpServerIP -port $nestVMServerSSHPort -command "ifconfig eth1 up $nestedVmIP netmask 255.255.255.0 up && route add default gw 192.168.0.1 && ifconfig eth0 down" -runAsSudo -RunInBackGround
-			Run-LinuxCmd -username $nestedUser -password $nestedPassword -ip $nttcpClientIP -port $nestVMServerSSHPort -command "ifconfig eth1 up $nestedVmIP netmask 255.255.255.0 up && route add default gw 192.168.0.1 && ifconfig eth0 down" -runAsSudo -RunInBackGround
+			Run-LinuxCmd -username $nestedUser -password $nestedPassword -ip $nttcpServerIP -port $nestVMServerSSHPort `
+				-command "ip addr add $nestedVmIP/24 dev eth1 && ip link set eth1 up && route add default gw 192.168.0.1 && ip link set eth0 down" `
+				-runAsSudo -RunInBackGround
+			Run-LinuxCmd -username $nestedUser -password $nestedPassword -ip $nttcpClientIP -port $nestVMServerSSHPort `
+				-command "ip addr add $nestedVmIP/24 dev eth1 && ip link set eth1 up && route add default gw 192.168.0.1 && ip link set eth0 down" `
+				-runAsSudo -RunInBackGround
 		} else {
 			Add-Content $constantsFile "nicName=eth0"
 			Copy-RemoteFiles -uploadTo $hs1VIP -port $nestVMServerSSHPort -files "$constantsFile" -username $nestedUser -password $nestedPassword -upload

--- a/Testscripts/Windows/STRESS-MTU-Netvsc-Reload.ps1
+++ b/Testscripts/Windows/STRESS-MTU-Netvsc-Reload.ps1
@@ -15,9 +15,12 @@ do
     modprobe hv_netvsc
     sleep 1
     pass=$((pass+1))
-    echo $pass > reload_netvsc.log
+    echo $pass >> reload_netvsc.log
 done
-ifdown eth0 && ifup eth0
+# this should not be required, consider for removal
+ip link set eth0 up
+echo "Interfaces status after hv_netvsc reload loop" >> reload_netvsc.log
+ip addr show >> reload_netvsc.log
 '@
 
 function Main {

--- a/Testscripts/Windows/VERIFY-INFINIBAND-MultiVM.ps1
+++ b/Testscripts/Windows/VERIFY-INFINIBAND-MultiVM.ps1
@@ -65,11 +65,11 @@ function Main {
         # We need to add extra parameters to constants.sh file apart from parameter properties defined in XML.
         # Hence, we are generating constants.sh file again in test script.
 
-        Write-LogInfo "Generating constansts.sh ..."
+        Write-LogInfo "Generating constants.sh ..."
         $constantsFile = "$LogDir\constants.sh"
         foreach ($TestParam in $CurrentTestData.TestParameters.param ) {
             Add-Content -Value "$TestParam" -Path $constantsFile
-            Write-LogInfo "$TestParam added to constansts.sh"
+            Write-LogInfo "$TestParam added to constants.sh"
             if ($TestParam -imatch "imb_mpi1_tests_iterations") {
                 $ImbMpiTestIterations = [int]($TestParam.Replace("imb_mpi1_tests_iterations=", "").Trim('"'))
             }
@@ -85,12 +85,12 @@ function Main {
         }
 
         Add-Content -Value "master=`"$($ServerVMData.InternalIP)`"" -Path $constantsFile
-        Write-LogInfo "master=$($ServerVMData.InternalIP) added to constansts.sh"
+        Write-LogInfo "master=$($ServerVMData.InternalIP) added to constants.sh"
 
         Add-Content -Value "slaves=`"$SlaveInternalIPs`"" -Path $constantsFile
-        Write-LogInfo "slaves=$SlaveInternalIPs added to constansts.sh"
+        Write-LogInfo "slaves=$SlaveInternalIPs added to constants.sh"
 
-        Write-LogInfo "constanst.sh created successfully..."
+        Write-LogInfo "constants.sh created successfully..."
         #endregion
 
         #region Upload files to master VM...
@@ -113,7 +113,7 @@ function Main {
                 foreach ( $ClientVMData in $ClientMachines ) {
                     Write-LogInfo "Getting initial MAC address info from $($ClientVMData.RoleName)"
                     Run-LinuxCmd -ip $ServerVMData.PublicIP -port $ServerVMData.SSHPort -username "root" `
-                        -password $password "ifconfig $InfinibandNic | grep ether | awk '{print `$2}' > InitialInfiniBandMAC.txt"
+                        -password $password "ip addr show $InfinibandNic | grep ether | awk '{print `$2}' > InitialInfiniBandMAC.txt"
                 }
             }
             else {
@@ -121,7 +121,7 @@ function Main {
                 foreach ( $ClientVMData in $ClientMachines ) {
                     Write-LogInfo "Step 1/2: Getting current MAC address info from $($ClientVMData.RoleName)"
                     $CurrentMAC = Run-LinuxCmd -ip $ServerVMData.PublicIP -port $ServerVMData.SSHPort -username "root" `
-                        -password $password "ifconfig $InfinibandNic | grep ether | awk '{print `$2}'"
+                        -password $password "ip addr show $InfinibandNic | grep ether | awk '{print `$2}'"
                     $InitialMAC = Run-LinuxCmd -ip $ServerVMData.PublicIP -port $ServerVMData.SSHPort -username "root" `
                         -password $password "cat InitialInfiniBandMAC.txt"
                     if ($CurrentMAC -eq $InitialMAC) {

--- a/XML/TestCases/FunctionalTests-Network.xml
+++ b/XML/TestCases/FunctionalTests-Network.xml
@@ -444,7 +444,7 @@
         <Priority>2</Priority>
     </test>
     <test>
-        <testName>VERIFY-IFUP-IFDOWN-RELOAD-HV_NETVSC-Synthetic</testName>
+        <testName>VERIFY-RESTART-INTERFACE-RELOAD-NETVSC</testName>
         <setupType>OneVM</setupType>
         <OverrideVMSize>Standard_D2_v2</OverrideVMSize>
         <AdditionalHWConfig>
@@ -453,8 +453,8 @@
         <TestParameters>
             <param>TestIterations=10</param>
         </TestParameters>
-        <testScript>verify-ifdown-ifup-eth0-rmmod-modprobe-hv-netvsc.sh</testScript>
-        <files>.\Testscripts\Linux\verify-ifdown-ifup-eth0-rmmod-modprobe-hv-netvsc.sh,.\TestScripts\Linux\utils.sh</files>
+        <testScript>restart-interface-reload-netvsc.sh</testScript>
+        <files>.\Testscripts\Linux\restart-interface-reload-netvsc.sh,.\TestScripts\Linux\utils.sh</files>
         <Platform>Azure</Platform>
         <Category>Functional</Category>
         <Area>NETWORK</Area>


### PR DESCRIPTION
ifconfig use is deprecated and newer distributions no longer include the package by default.
Replace ifconfig/ifdown/ifup commands with the new set of ip commands.

Rewrite VLAN interface create to not use interface config file, but rather only to current boot session.
*This model should be carried to further code refactor for configuring the secondary interfaces as well.*

Also rename testcase name and file "verify-ifdown-ifup-eth0-rmmod-modprobe-hv-netvsc.sh" to a shorter version.

---

Azure:
ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : latest
BVT-CORE-RELOAD-MODULES-SMP                                                       PASS                11.36 <- also pass on Hyper-V
VERIFY-RESTART-INTERFACE-RELOAD-NETVSC                                            PASS                 2.05
HyperV:
NET-MAX-SYNTHETIC-NICS                                                            PASS                 3.72
NET-VLAN-TAGGING                                                                  PASS                 7.32
NET-VLAN-TRUNKING                                                                 PASS                 6.72