### PR TITLE
hyperv: don't apply checkpoints on the first run and retry to remove snaspshots

### DIFF
--- a/Libraries/HyperV.psm1
+++ b/Libraries/HyperV.psm1
@@ -191,15 +191,11 @@ Function Delete-HyperVGroup([string]$HyperVGroupName, [string]$HyperVHost, $Setu
             Remove-VMSnapshot -VMName $vm.Name -ComputerName $HyperVHost `
                 -IncludeAllChildCheckpoints -Confirm:$false -ErrorAction SilentlyContinue
             if ($?) {
-                Write-LogWarn ("Failed to remove snapshots for VM {0}. Retrying $($retriesCleanSnapshots+1)/${maxRetriesCleanSnapshots}..." -f @($vm.Name))
+                Write-LogWarn ("Failed to remove snapshots for VM {0}. Retrying..." -f @($vm.Name))
                 $retriesCleanSnapshots++
             } else {
                 break
             }
-        }
-        if ($retriesCleanSnapshots -eq $maxRetriesCleanSnapshots) {
-            Write-LogErr ("Failed to remove snapshots for VM {0}" -f @($vm.Name))
-            return $false
         }
         Wait-VMStatus -VMName $vm.Name -VMStatus "Operating Normally" -RetryInterval 2 `
             -HvServer $HyperVHost
@@ -217,13 +213,15 @@ Function Delete-HyperVGroup([string]$HyperVGroupName, [string]$HyperVHost, $Setu
             }
             Invoke-Command @invokeCommandParams
             if (!$?) {
-                Write-LogInfo "Failed to remove ${vhdPath} using Invoke-Command"
                 $vhdUncPath = $vhdPath -replace '^(.):', "\\${HyperVHost}\`$1$"
-                Write-LogInfo "Removing ${vhdUncPath} ..."
-                Remove-Item -Path $vhdUncPath -Force
-                if (!$? -or (Test-Path $vhdUncPath)) {
-                    Write-LogErr "Failed to remove ${vhdPath} using UNC paths"
-                    return $false
+                if ((Test-Path $vhdUncPath)) {
+                    Write-LogWarn "Failed to remove ${vhdPath} using Invoke-Command"
+                    Write-LogInfo "Removing ${vhdUncPath} ..."
+                    Remove-Item -Path $vhdUncPath -Force
+                    if (!$? -or (Test-Path $vhdUncPath)) {
+                        Write-LogErr "Failed to remove ${vhdPath} using UNC paths"
+                        return $false
+                    }
                 }
             }
             Write-LogInfo "VHD ${vhdPath} removed!"

--- a/TestControllers/TestController.psm1
+++ b/TestControllers/TestController.psm1
@@ -266,7 +266,7 @@ Class TestController
 
 	[void] PrepareTestImage() {}
 
-	[object] RunTestCase($VmData, $CurrentTestData, $ExecutionCount, $SetupTypeData) {
+	[object] RunTestCase($VmData, $CurrentTestData, $ExecutionCount, $SetupTypeData, $ApplyCheckpoint) {
 		# Prepare test case log folder
 		$currentTestName = $($CurrentTestData.testName)
 		$oldLogDir = $global:LogDir
@@ -291,7 +291,7 @@ Class TestController
 			}
 
 			# Run setup script if any
-			$this.TestProvider.RunSetup($VmData, $CurrentTestData, $testParameters)
+			$this.TestProvider.RunSetup($VmData, $CurrentTestData, $testParameters, $ApplyCheckpoint)
 
 			# Upload test files to VMs
 			if ($CurrentTestData.files) {
@@ -369,6 +369,7 @@ Class TestController
 
 			$vmData = $null
 			$lastResult = $null
+			$tests = 0
 			foreach ($case in $this.SetupTypeToTestCases[$key]) {
 				$originalTestName = $case.TestName
 				for ( $testIterationCount = 1; $testIterationCount -le $this.TestIterations; $testIterationCount ++ ) {
@@ -389,7 +390,8 @@ Class TestController
 						}
 					}
 					# Run test case
-					$lastResult = $this.RunTestCase($vmData, $case, $executionCount, $this.SetupTypeTable[$setupType])
+					$lastResult = $this.RunTestCase($vmData, $case, $executionCount, $this.SetupTypeTable[$setupType], ($tests -eq 0))
+					$tests++
 					# If the case doesn't pass, keep the VM for failed case except when ForceDeleteResources is set
 					# and deploy a new VM for the next test
 					if ($lastResult.TestResult -ne "PASS") {

--- a/TestProviders/HyperVProvider.psm1
+++ b/TestProviders/HyperVProvider.psm1
@@ -99,11 +99,11 @@ Class HyperVProvider : TestProvider
 		return $allVMData
 	}
 
-	[void] RunSetup($VmData, $CurrentTestData, $TestParameters) {
+	[void] RunSetup($VmData, $CurrentTestData, $TestParameters, $ApplyCheckPoint) {
 		if ($CurrentTestData.AdditionalHWConfig.HyperVApplyCheckpoint -eq "False") {
 			Remove-AllFilesFromHomeDirectory -allDeployedVMs $VmData
 			Write-LogInfo "Removed all files from home directory."
-		} else  {
+		} elseif ($ApplyCheckPoint) {
 			Apply-HyperVCheckpoint -VMData $VmData -CheckpointName "ICAbase"
 			$VmData = Check-IP -VMData $VmData
 			Write-LogInfo "Public IP found for all VMs in deployment after checkpoint restore"

--- a/TestProviders/TestProvider.psm1
+++ b/TestProviders/TestProvider.psm1
@@ -35,7 +35,7 @@ Class TestProvider
 		return $null
 	}
 
-	[void] RunSetup($VmData, $CurrentTestData, $TestParameters) {}
+	[void] RunSetup($VmData, $CurrentTestData, $TestParameters, $ApplyCheckPoint) {}
 
 	[void] RunTestCaseCleanup ($AllVMData, $CurrentTestData, $CurrentTestResult, $CollectVMLogs, $RemoveFiles, $User, $Password, $SetupTypeData, $TestParameters){
 		# Remove running background jobs


### PR DESCRIPTION
hyperv: retry to remove snapshots on failure

hyperv: don't revert unneeded snasphots when the first test case is run, as it is not needed

Execution tested on HyperV:

```
   ID TestCaseName                                                                TestResult TestDuration(in minutes)
---------------------------------------------------------------------------------------------------------------------
    1 BVT-CORE-VERIFY-LIS-MODULES                                                       PASS                 0.95
```