### PR TITLE
kdump: increase crashkernel memory allocation

### DIFF
--- a/XML/TestCases/FunctionalTests.xml
+++ b/XML/TestCases/FunctionalTests.xml
@@ -460,7 +460,7 @@
         <TestParameters>
             <param>vmCpuNumber=1</param>
             <param>vmMemory=4GB</param>
-            <param>crashkernel=384M@128M</param>
+            <param>crashkernel=512M</param>
         </TestParameters>
         <Platform>HyperV,Azure</Platform>
         <Category>Functional</Category>
@@ -494,7 +494,7 @@
         <TestParameters>
             <param>vmCpuNumber=3</param>
             <param>vmMemory=3GB</param>
-            <param>crashkernel=384M@128M</param>
+            <param>crashkernel=512M</param>
             <param>NMI=1</param>
         </TestParameters>
         <Platform>HyperV</Platform>
@@ -529,7 +529,7 @@
         <TestParameters>
             <param>vmCpuNumber=4</param>
             <param>vmMemory=2GB</param>
-            <param>crashkernel=384M@128M</param>
+            <param>crashkernel=512M</param>
         </TestParameters>
         <Platform>HyperV,Azure</Platform>
         <Category>Functional</Category>
@@ -546,7 +546,7 @@
         <TestParameters>
             <param>vmCpuNumber=16</param>
             <param>vmMemory=4GB</param>
-            <param>crashkernel=512M@128M</param>
+            <param>crashkernel=512M</param>
         </TestParameters>
         <Platform>HyperV,Azure</Platform>
         <Category>Functional</Category>


### PR DESCRIPTION
Using a larger crashkernel size is required for newer kernels, azure kernel or upstream take much more memory during crash.

Hyper-V :
VHD Under Test        : ubuntu_18.04.1.vhdx
Total Test Cases      : 1 (1 Pass, 0 Fail, 0 Abort)
Total Time (dd:hh:mm) : 0:0:8

   ID TestCaseName                                                                TestResult TestDuration(in minutes) 
---------------------------------------------------------------------------------------------------------------------
    1 KDUMP-CRASH-NMI                                                                   PASS                 6.24 

Azure : 

ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : latest
Total Test Cases      : 2 (2 Pass, 0 Fail, 0 Abort)
Total Time (dd:hh:mm) : 0:0:9

   ID TestCaseName                                                                TestResult TestDuration(in minutes) 
---------------------------------------------------------------------------------------------------------------------
    1 KDUMP-CRASH-SINGLE-CORE                                                           PASS                 4.22 
    2 KDUMP-CRASH-DIFFERENT-VCPU                                                        PASS                 3.38 


ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : latest
Total Test Cases      : 1 (1 Pass, 0 Fail, 0 Abort)
Total Time (dd:hh:mm) : 0:0:6

   ID TestCaseName                                                                TestResult TestDuration(in minutes) 
---------------------------------------------------------------------------------------------------------------------
    1 KDUMP-CRASH-16-CORES                                    