### PR TITLE
Fix STRESSTEST-CHANGE-MTU-RELOAD-NETVSC

### DIFF
--- a/Libraries/IntegrationServiceLibrary.psm1
+++ b/Libraries/IntegrationServiceLibrary.psm1
@@ -279,13 +279,15 @@ function Get-IPv4AndWaitForSSHStart {
 	}
 
 	# Cache fingerprint, Check ssh is functional after reboot
-	Write-Output "yes" | .\Tools\plink.exe -C -pw $Password -P $VmPort $User@$new_ip 'exit 0'
+	$null = Write-Output "yes" | .\Tools\plink.exe -C -pw $Password -P $VmPort $User@$new_ip 'exit 0'
+	Write-LogInfo ".\Tools\plink.exe -C -pw $Password -P $VmPort $User@$new_ip"
 	$TestConnection = .\Tools\plink.exe -C -pw $Password -P $VmPort $User@$new_ip "echo Connected"
-	if ($TestConnection -ne "Connected") {
+	if (-not ($TestConnection)) {
 		Write-LogErr "Get-IPv4AndWaitForSSHStart: SSH is not working correctly after boot up"
 		return $False
+	} else {
+		Write-LogInfo "SSH connection returns : $TestConnection"
 	}
-
 	return $new_ip
 }
 


### PR DESCRIPTION
Addressing #626 
Verification Tests : 

01/22/2019 17:48:22 : [INFO ] SSH connection returns : Connected
01/22/2019 17:48:22 : [INFO ] Successfully reloaded hv_netvsc for 25 times

[LISAv2 Test Results Summary]
Test Run On           : 01/22/2019 17:32:18
VHD Under Test      :ubuntu_18.04.1.vhdx
Total Test Cases      : 1 (1 Pass, 0 Fail, 0 Abort)
Total Time (dd:hh:mm) : 0:0:16

   ID TestCaseName                                                                TestResult TestDuration(in minutes) 
---------------------------------------------------------------------------------------------------------------------
    1 STRESSTEST-CHANGE-MTU-RELOAD-NETVSC                                               PASS                14.42 

01/22/2019 18:29:40 : [INFO ] SSH connection returns : Connected
01/22/2019 18:29:40 : [INFO ] Successfully reloaded hv_netvsc for 25 times

[LISAv2 Test Results Summary]
Test Run On           : 01/22/2019 18:13:47
VHD Under Test        : Centos_7.5_x64.vhdx
Total Test Cases      : 1 (1 Pass, 0 Fail, 0 Abort)
Total Time (dd:hh:mm) : 0:0:16

   ID TestCaseName                                                                TestResult TestDuration(in minutes) 
---------------------------------------------------------------------------------------------------------------------
    1 STRESSTEST-CHANGE-MTU-RELOAD-NETVSC                                               PASS                14.37 

