### PR TITLE
Fix functionality of Get-IPv4AndWaitForSSHStart in testcases

### DIFF
--- a/Testscripts/Windows/SETUP-STOR-TakeRevert-Snapshot.ps1
+++ b/Testscripts/Windows/SETUP-STOR-TakeRevert-Snapshot.ps1
@@ -110,23 +110,13 @@ function Main {
     #
     # Start the VM and wait up to 5 minutes for it to come up
     #
-    $timeout = 300
 
     Start-VM $VMName -ComputerName $HvServer
 
-    while ($timeout -gt 0) {
-        $newIpv4 = Get-Ipv4AndWaitForSSHStart $VMName $HvServer $VMPort $VMUserName `
-                   $VMPassword 300
-        if ($newIpv4 -ne $Null) {
-            break
-        }
-
-        Start-Sleep -S 6
-        $timeout -= 3
-    }
-
-    if ($timeout -eq 0) {
-        Write-LogErr "Test case timed out waiting for VM to boot!"
+    $newIpv4 = Get-Ipv4AndWaitForSSHStart -VmName $VMName -HvServer $HvServer -Vmport $VMPort -User $VMUserName `
+              -Password $VMPassword -StepTimeout 300
+    if (-not $newIpv4) {
+        Write-LogErr "Failed to retrive $VMName IP after snasphot restore"
         return "FAIL"
     }
     #

--- a/Testscripts/Windows/SRIOV-REBOOT-VM.ps1
+++ b/Testscripts/Windows/SRIOV-REBOOT-VM.ps1
@@ -56,7 +56,7 @@ function Main {
     Restart-VM -VMName $VMName -ComputerName $HvServer -Force
     $newIpv4 = Get-Ipv4AndWaitForSSHStart $VMName $HvServer $VMPort $VMUsername `
         $VMPassword $timeout
-    if ($null -eq $newIpv4) {
+    if (-not $newIpv4) {
         Write-LogErr "Failed to get IP of $VMName on $HvServer"
         return "FAIL"
     }


### PR DESCRIPTION
Addressing #626

[LISAv2 Test Results Summary]
Test Run On           : 01/23/2019 17:31:31
VHD Under Test        : Centos_7.5_x64.vhdx
Total Test Cases      : 1 (1 Pass, 0 Fail, 0 Abort)
Total Time (dd:hh:mm) : 0:0:9

   ID TestCaseName                                                                TestResult TestDuration(in minutes) 
---------------------------------------------------------------------------------------------------------------------
    1 SRIOV-REBOOT-VM                                                                   PASS                 7.51 



[LISAv2 Test Results Summary]
Test Run On           : 01/23/2019 18:12:16
VHD Under Test        : ubuntu_18.04.1.vhdx
Total Test Cases      : 1 (1 Pass, 0 Fail, 0 Abort)
Total Time (dd:hh:mm) : 0:0:11

   ID TestCaseName                                                                TestResult TestDuration(in minutes) 
---------------------------------------------------------------------------------------------------------------------
    1 SRIOV-REBOOT-VM                                                                   PASS                 7.22 


[LISAv2 Test Results Summary]
Test Run On           : 01/23/2019 20:46:56
VHD Under Test        : Centos_7.5_x64.vhdx
Total Test Cases      : 1 (1 Pass, 0 Fail, 0 Abort)
Total Time (dd:hh:mm) : 0:0:6

   ID TestCaseName                                                                TestResult TestDuration(in minutes) 
---------------------------------------------------------------------------------------------------------------------
    1 STORAGE-TAKE-REVERT-SNAPSHOT                                                      PASS                 3.63 


[LISAv2 Test Results Summary]
Test Run On           : 01/23/2019 20:57:56
VHD Under Test        : ubuntu_18.04.1.vhdx
Total Test Cases      : 1 (1 Pass, 0 Fail, 0 Abort)
Total Time (dd:hh:mm) : 0:0:7

   ID TestCaseName                                                                TestResult TestDuration(in minutes) 
---------------------------------------------------------------------------------------------------------------------
    1 STORAGE-TAKE-REVERT-SNAPSHOT                                                      PASS                 4.44 
