### PR TITLE
STRESSTEST-WEB-PARALLEL-ACCESS: Restrict test only to Ubuntu/Debian

### DIFF
--- a/Testscripts/Windows/STRESS-Web.ps1
+++ b/Testscripts/Windows/STRESS-Web.ps1
@@ -120,6 +120,11 @@ function Main()
         Write-LogInfo "  Second Internal IP : $serverSecondInternalIP"
         Write-LogInfo "  SSH Port : $serverSSHPort"
 
+        $linuxRelease = Detect-LinuxDistro -VIP $serverPublicIP -SSHPort $serverSSHPort -testVMuser $username -testVMPassword $password
+        if ($linuxRelease -ne "UBUNTU" -or $linuxRelease -ne "DEBIAN") {
+            Write-LogErr "Test is only supported on Debian based distributions ..."
+            return "FAIL"
+        }
         Write-LogInfo "Install nginx on server vm: $serverPublicIP"
         $cmd = ". utils.sh && update_repos && install_package nginx"
         Run-LinuxCmd -ip $serverPublicIP -port $serverSSHPort -username $username -password $password -command $cmd -runAsSudo


### PR DESCRIPTION
Addressing #593
Until further requirement to  support this test on other distributions, restrict it only to Debian/Ubuntu.
CentOS/Redhat will require epel repo setup to install nginx and further automation code.