### PR TITLE
lisav2: hyperv: remove SourceOsVHDPath parameter

### DIFF
--- a/LISAv2-Framework.psm1
+++ b/LISAv2-Framework.psm1
@@ -22,9 +22,6 @@ function Start-LISAv2 {
 		[string] $ARMImageName = "",
 		[string] $StorageAccount="",
 
-		# [Required] for HyperV
-		[string] $SourceOsVHDPath="",
-
 		# [Required] for Two Hosts HyperV
 		[string] $DestinationOsVHDPath="",
 

--- a/Libraries/HyperV.psm1
+++ b/Libraries/HyperV.psm1
@@ -44,7 +44,6 @@ Function Create-AllHyperVGroupDeployments($SetupTypeData, $GlobalConfig, $TestLo
             $HyperVHostArray += $GlobalConfig.Global.HyperV.Hosts.ChildNodes[$index].ServerName
         }
 
-        $SourceOsVHDPath = $GlobalConfig.Global.HyperV.Hosts.ChildNodes[$index].SourceOsVHDPath
         if ($SetupTypeData.ClusteredVM) {
             $ClusterVolume = Get-ClusterSharedVolume
             $DestinationOsVHDPath = $ClusterVolume.SharedVolumeInfo.FriendlyVolumeName
@@ -99,7 +98,7 @@ Function Create-AllHyperVGroupDeployments($SetupTypeData, $GlobalConfig, $TestLo
                         $ExpectedVMs = 0
                         $HyperVGroupXML.VirtualMachine | ForEach-Object {$ExpectedVMs += 1}
                         $VMCreationStatus = Create-HyperVGroupDeployment -HyperVGroupName $HyperVGroupName -HyperVGroupXML $HyperVGroupXML `
-                            -HyperVHost $HyperVHostArray -SourceOsVHDPath $SourceOsVHDPath -DestinationOsVHDPath $DestinationOsVHDPath `
+                            -HyperVHost $HyperVHostArray -DestinationOsVHDPath $DestinationOsVHDPath `
                             -VMGeneration $VMGeneration -GlobalConfig $GlobalConfig -SetupTypeData $SetupTypeData -CurrentTestData $TestCaseData
 
                         $DeploymentEndTime = (Get-Date)
@@ -297,7 +296,7 @@ Function Create-HyperVGroup([string]$HyperVGroupName, [string]$HyperVHost)
     return $retValue
 }
 
-Function Create-HyperVGroupDeployment([string]$HyperVGroupName, $HyperVGroupXML, $HyperVHost, $SourceOsVHDPath, $DestinationOsVHDPath, $VMGeneration,
+Function Create-HyperVGroupDeployment([string]$HyperVGroupName, $HyperVGroupXML, $HyperVHost, $DestinationOsVHDPath, $VMGeneration,
     $GlobalConfig, $SetupTypeData, $CurrentTestData)
 {
     $HyperVMappedSizes = [xml](Get-Content .\XML\AzureVMSizeToHyperVMapping.xml)
@@ -313,7 +312,6 @@ Function Create-HyperVGroupDeployment([string]$HyperVGroupName, $HyperVGroupXML,
             if ($VirtualMachine.DeployOnDifferentHyperVHost -and ($TestLocation -match ",")) {
                 $hostNumber = $HyperVGroupXML.VirtualMachine.indexOf($VirtualMachine)
                 $HyperVHost = $GlobalConfig.Global.HyperV.Hosts.ChildNodes[$hostNumber].ServerName
-                $SourceOsVHDPath = $GlobalConfig.Global.HyperV.Hosts.ChildNodes[$hostNumber].SourceOsVHDPath
                 if ($SetupTypeData.ClusteredVM) {
                     $ClusterVolume = Get-ClusterSharedVolume
                     $DestinationOsVHDPath = $ClusterVolume.SharedVolumeInfo.FriendlyVolumeName
@@ -337,9 +335,6 @@ Function Create-HyperVGroupDeployment([string]$HyperVGroupName, $HyperVGroupXML,
             }
 
             $parentOsVHDPath = $OsVHD
-            if ($SourceOsVHDPath) {
-                $parentOsVHDPath = Join-Path $SourceOsVHDPath $OsVHD
-            }
             $uriParentOsVHDPath = [System.Uri]$parentOsVHDPath
             if ($uriParentOsVHDPath -and $uriParentOsVHDPath.isUnc) {
                 Write-LogInfo "Parent VHD path ${parentOsVHDPath} is on an SMB share."

--- a/README.md
+++ b/README.md
@@ -106,13 +106,11 @@ Please follow the steps mentioned at [here](https://docs.microsoft.com/en-us/azu
             <Host>
                 <!--ServerName can be localhost or Hyper-V host name-->
                 <ServerName>localhost</ServerName>
-                <SourceOsVHDPath></SourceOsVHDPath>
                 <DestinationOsVHDPath>VHDs_Destination_Path</DestinationOsVHDPath>
             </Host>
             <Host>
                 <!--If run test against 2 hosts, set ServerName as another host computer name-->
                 <ServerName>lis-01</ServerName>
-                <SourceOsVHDPath></SourceOsVHDPath>
                 <!--If run test against 2 hosts, DestinationOsVHDPath is mandatory-->
                 <DestinationOsVHDPath>D:\vhd</DestinationOsVHDPath>
             </Host>

--- a/Run-LisaV2.ps1
+++ b/Run-LisaV2.ps1
@@ -40,9 +40,6 @@ Param(
 	[string] $ARMImageName = "",
 	[string] $StorageAccount="",
 
-	# [Required] for HyperV
-	[string] $SourceOsVHDPath="",
-
 	# [Required] for Two Hosts HyperV
 	[string] $DestinationOsVHDPath="",
 

--- a/TestControllers/HyperVController.psm1
+++ b/TestControllers/HyperVController.psm1
@@ -29,7 +29,6 @@ using Module "..\TestProviders\HyperVProvider.psm1"
 
 Class HyperVController : TestController
 {
-	[string] $SourceOsVhdPath
 	[string] $DestinationOsVhdPath
 
 	HyperVController() {
@@ -38,7 +37,6 @@ Class HyperVController : TestController
 	}
 
 	[void] ParseAndValidateParameters([Hashtable]$ParamTable) {
-		$this.SourceOsVhdPath = $ParamTable["SourceOsVhdPath"]
 		$this.DestinationOsVhdPath = $ParamTable["DestinationOsVhdPath"]
 		$vmGeneration = [string]($ParamTable["VMGeneration"])
 		$this.TestProvider.VMGeneration = $vmGeneration
@@ -86,12 +84,6 @@ Class HyperVController : TestController
 		}
 		$this.VmUsername = $hyperVConfig.TestCredentials.LinuxUsername
 		$this.VmPassword = $hyperVConfig.TestCredentials.LinuxPassword
-		if ( $this.SourceOsVHDPath )
-		{
-			for( $index=0 ; $index -lt $hyperVConfig.Hosts.ChildNodes.Count ; $index++ ) {
-				$hyperVConfig.Hosts.ChildNodes[$index].SourceOsVHDPath = $this.SourceOsVHDPath
-			}
-		}
 		if ( $this.DestinationOsVHDPath )
 		{
 			for( $index=0 ; $index -lt $hyperVConfig.Hosts.ChildNodes.Count ; $index++ ) {
@@ -144,7 +136,6 @@ Class HyperVController : TestController
 		$serverCount = $this.TestLocation.split(',').Count
 		for( $index=0 ; $index -lt $serverCount ; $index++ ) {
 			Write-LogInfo "HyperV Host            : $($hyperVConfig.Hosts.ChildNodes[$($index)].ServerName)"
-			Write-LogInfo "Source VHD Path        : $($hyperVConfig.Hosts.ChildNodes[$($index)].SourceOsVHDPath)"
 			Write-LogInfo "Destination VHD Path   : $($hyperVConfig.Hosts.ChildNodes[$($index)].DestinationOsVHDPath)"
 		}
 		Write-LogInfo "------------------------------------------------------------------"

--- a/XML/GlobalConfigurations.xml
+++ b/XML/GlobalConfigurations.xml
@@ -24,12 +24,10 @@
         <Hosts>
             <Host>
                 <ServerName>localhost</ServerName>
-                <SourceOsVHDPath></SourceOsVHDPath>
                 <DestinationOsVHDPath>VHDs_Destination_Path</DestinationOsVHDPath>
             </Host>
             <Host>
                 <ServerName>localhost</ServerName>
-                <SourceOsVHDPath></SourceOsVHDPath>
                 <DestinationOsVHDPath>VHDs_Destination_Path</DestinationOsVHDPath>
             </Host>
         </Hosts>

--- a/XML/TestParameters.xml
+++ b/XML/TestParameters.xml
@@ -45,9 +45,6 @@
 	<ARMImageName></ARMImageName>
 	<StorageAccount></StorageAccount>
 
-	<!-- [Required] for HyperV -->
-	<SourceOsVHDPath></SourceOsVHDPath>
-
 	<!-- [Required] for Two Hosts HyperV -->
 	<DestinationOsVHDPath></DestinationOsVHDPath>
 


### PR DESCRIPTION
SourceOsVHDPath parameter is not needed anymore, as now the OSVhd is already given in pipelines as a full path.

Previously to this patch, if SourceOSVhd existed, the full path of the lisav2 used vhd was the SourceOSVhd  + OsVhd.

Execution tested:

```
[LISAv2 Test Results Summary]
Test Run On           : 01/29/2019 16:09:59
VHD Under Test        : D:\diskimages\ubuntu-1810.vhdx
Total Test Cases      : 1 (1 Pass, 0 Fail, 0 Abort)
Total Time (dd:hh:mm) : 0:0:3

   ID TestCaseName                                                                TestResult TestDuration(in minutes)
---------------------------------------------------------------------------------------------------------------------
    1 BVT-CORE-VERIFY-LIS-MODULES                                                       PASS                  1.9

```