### PR TITLE
NVMe Direct: Add 2 new test-cases

### DIFF
--- a/Testscripts/Linux/nvme_blkdiscard.sh
+++ b/Testscripts/Linux/nvme_blkdiscard.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache License.
+#
+# Description:
+# Functional NVME test script. For each NVME device it does the following:
+# - Partition nvme0n1 (a single partition). Create xfs filesystem and mount the partition.
+# - Unmount the partition
+# - Run "blkdiscard /dev/nvme0n1p1"
+# - Try to mount the partition again “mount /dev/nvme0n1p1 mountPoint” – it should fail
+##########################################################################################
+
+. utils.sh || {
+    echo "ERROR: unable to source utils.sh!"
+    echo "TestAborted" > state.txt
+    exit 0
+}
+UtilsInit
+Run_Blkdiscard() {
+    # Install nvme-cli tool and parted
+    update_repos
+    install_package "nvme-cli"
+    # Count NVME namespaces
+    namespace_count=$(echo /dev/*nvme*n[0-9] | wc -w)
+    if [ "$namespace_count" -eq "0" ]; then
+        LogErr "No NVME namespaces detected inside the VM"
+        SetTestStateFailed
+        exit 0
+    fi
+    namespace_list=$(find /dev -name 'nvme*n[0-9]' | cut -d/ -f3)
+    for namespace in ${namespace_list}; do
+        # Remove previous partitions or RAID config
+        umount "$namespace"
+        (echo d; echo w) | fdisk "/dev/${namespace}"
+        sync
+        #Format and mount nvme to namespace
+        Format_Mount_NVME ${namespace} xfs
+        #unmont
+        umount "$namespace"
+        if [ $? -ne 0 ]; then
+            LogErr "Failed to unmount ${namespace}"
+            SetTestStateFailed
+            exit 0
+        else
+            LogMsg "Unmounted ${namespace}"
+        fi
+        #Run blkdiscard on partition
+        blkdiscard  -v "/dev/${namespace}p1"
+        if [ $? -ne 0 ]; then
+            LogErr "Failed to run blkdiscard on ${namespace}"
+            SetTestStateFailed
+            exit 0
+        else
+            LogMsg "Blkdiscard ran successfully"
+        fi
+        #Check mount after discard
+        mount "/dev/${namespace}p1" "$namespace"
+        if [ $? -eq 0 ]; then
+            LogErr "Mounted ${namespace}p1 Test failed "
+            SetTestStateFailed
+            exit 0
+        else
+            LogMsg "Failed to mount ${namespace}p1 Blkdiscard successful"
+        fi
+        UpdateSummary "All the operations on ${namespace} worked as expected!"
+    done
+    # All the operations succeeded and the test is complete
+    SetTestStateCompleted
+    exit 0
+}
+#Run testcase
+Run_Blkdiscard

--- a/Testscripts/Linux/nvme_fstrim.sh
+++ b/Testscripts/Linux/nvme_fstrim.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache License.
+#
+# Description:
+# Fstrim NVME test script. For each NVME device it does the following:
+# - Partition nvme0n1 (a single partition). Create xfs filesystem and mount the partition.
+# - fstrim mountPoint  -v => check how much is trimmed. 1.8 TiB should be the output of fstrim
+#  (e.g. nvme0n1: 1.8 TiB (1919444512768 bytes) trimmed)
+# - Create a 300 gb file using "dd if=/dev/zero mountPoint/data bs=1G count=300"
+# - fstrim mountPoint  -v => 1.5 TiB should be the output of fstrim
+#  (e.g. nvme0n1: 1.5 TiB (1604871708672 bytes) trimmed
+# - Remove file
+# - fstrim mountPoint -v => 1.8 TiB should be trimmed again.
+#If every trim size check is as expected, test is successful.
+#########################################################################
+
+. utils.sh || {
+    echo "ERROR: unable to source utils.sh!"
+    echo "TestAborted" > state.txt
+    exit 0
+}
+UtilsInit
+Run_Fstrim() {
+    # Install nvme-cli tool and parted
+    update_repos
+    install_package "nvme-cli"
+    # Count NVME namespaces
+    namespace_count=$(echo /dev/nvme*n[0-9] | wc -w)
+    if [ "$namespace_count" -eq "0" ]; then
+        LogErr "No NVME namespaces detected inside the VM"
+        SetTestStateFailed
+        exit 0
+    fi
+    namespace_list=$(find /dev -name 'nvme*n[0-9]' | cut -d/ -f3)
+    for namespace in ${namespace_list}; do
+        # Remove previous partitions or RAID config
+        umount "$namespace"
+        (echo d; echo w) | fdisk "/dev/${namespace}"
+        sync
+        #Format and mount nvme to namespace
+        Format_Mount_NVME "${namespace}" xfs
+        #check how much is trimmed intially
+        trim_init=$(fstrim  "$namespace" -v)
+        if [ $? -ne 0 ]; then
+            LogErr "Failed to check intial trim on ${namespace}"
+            SetTestStateFailed
+            exit 0
+        else
+            LogMsg "Initial Trim size :$trim_init"
+        fi
+        # Create files on the partition
+        dd if=/dev/zero of="$namespace"/data bs=1G count=300
+        if [ $? -ne 0 ]; then
+            LogErr "Failed to create 300GB file on ${namespace}"
+            SetTestStateFailed
+            exit 0
+        else
+            LogMsg "Create 300GB file on ${namespace}"
+        fi
+        #check how much is trimmed after file is created
+        trim_file=$(fstrim  "$namespace" -v)
+        if [ $? -ne 0 ]; then
+            LogErr "Failed to check trim size after file creation on ${namespace}"
+            SetTestStateFailed
+            exit 0
+        else
+            LogMsg "Trim size after file creation:$trim_file"
+        fi
+        # Delete file
+        rm -rf "$namespace"/data
+        if [ $? -ne 0 ]; then
+            LogErr "Failed to ${namespace}/data"
+            SetTestStateFailed
+            exit 0
+        fi
+        #check how much is trimmed after file is created
+        trim_final=$(fstrim  "$namespace" -v)
+        if [ $? -ne 0 ]; then
+            LogErr "Failed to check trim size after file creation on ${namespace}"
+            SetTestStateFailed
+            exit 0
+        else
+            LogMsg "Trim size after file creation:$trim_final"
+        fi
+        #check how much is trimmed after file is created
+        if [ "$trim_final" -ne "$trim_init" ]; then
+            LogErr "Final trim size does not match initial trim size"
+            SetTestStateFailed
+            exit 0
+        else
+            LogMsg "Final trim size matched with initial trim size"
+        fi
+        #unmont
+        umount "$namespace"
+        if [ $? -ne 0 ]; then
+            LogErr "Failed to unmount ${namespace}"
+            SetTestStateFailed
+            exit 0
+        else
+            LogMsg "Unmounted ${namespace}"
+        fi
+        UpdateSummary "All the operations on ${namespace} worked as expected!"
+    done
+    # All the operations succeeded and the test is complete
+    SetTestStateCompleted
+    exit 0
+}
+#Run testcase
+Run_Fstrim

--- a/Testscripts/Linux/utils.sh
+++ b/Testscripts/Linux/utils.sh
@@ -3295,3 +3295,31 @@ function ConsumeMemory() {
     wait
     return 0
 }
+
+function Format_Mount_NVME()
+{
+    if [[ $# == 2 ]]; then
+        local namespace=$1
+        local filesystem=$2
+    else
+        return 1
+    fi
+    # Partition disk
+    echo "Creating  partition on ${namespace} disk "
+    (echo n; echo p; echo 1; echo ; echo; echo ; echo w) | fdisk /dev/"${namespace}"
+    check_exit_status "${namespace} partition creation"
+    sleep 1
+    # Create fileSystem
+    echo "Creating ${filesystem} filesystem on ${namespace} disk "
+    echo "y" | mkfs."${filesystem}" -f "/dev/${namespace}p1"
+    check_exit_status "${filesystem} filesystem creation"
+    sleep 1
+    # Mount the disk
+    LogMsg "Mounting ${namespace}p1 disk "
+    mkdir "$namespace"
+    mount "/dev/${namespace}p1" "$namespace"
+    check_exit_status "${filesystem} filesystem Mount"
+    sleep 1
+    return 0
+}
+

--- a/XML/TestCases/FunctionalTests-NVME.xml
+++ b/XML/TestCases/FunctionalTests-NVME.xml
@@ -9,6 +9,7 @@
         <testParameters>
             <param>HYPERV_DISK_COUNT=2</param>
         </testParameters>
+        <Timeout>1200</Timeout>
         <cleanupScript>.\Testscripts\Windows\SETUP-Remove-NVME-Disk.ps1</cleanupScript>
         <Platform>Azure,HyperV</Platform>
         <Category>Functional</Category>
@@ -26,6 +27,7 @@
         <testParameters>
             <param>HYPERV_DISK_COUNT=1</param>
         </testParameters>
+        <Timeout>1200</Timeout>
         <cleanupScript>.\Testscripts\Windows\SETUP-Remove-NVME-Disk.ps1</cleanupScript>
         <Platform>Azure,HyperV</Platform>
         <Category>Functional</Category>
@@ -43,6 +45,43 @@
         <testParameters>
             <param>HYPERV_DISK_COUNT=1</param>
         </testParameters>
+        <Timeout>1200</Timeout>
+        <cleanupScript>.\Testscripts\Windows\SETUP-Remove-NVME-Disk.ps1</cleanupScript>
+        <Platform>Azure,HyperV</Platform>
+        <Category>Functional</Category>
+        <Area>NVME</Area>
+        <Tags>nvme</Tags>
+        <Priority>0</Priority>
+    </test>
+    <test>
+        <testName>NVME-FSTRIM</testName>
+        <testScript>nvme_fstrim.sh</testScript>
+        <setupScript>.\Testscripts\Windows\SETUP-Add-NVME-Disk.ps1</setupScript>
+        <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\nvme_fstrim.sh</files>
+        <setupType>OneVM</setupType>
+        <OverrideVMSize>Standard_L8s_v2</OverrideVMSize>
+        <testParameters>
+            <param>HYPERV_DISK_COUNT=1</param>
+        </testParameters>
+        <Timeout>3600</Timeout>
+        <cleanupScript>.\Testscripts\Windows\SETUP-Remove-NVME-Disk.ps1</cleanupScript>
+        <Platform>Azure,HyperV</Platform>
+        <Category>Functional</Category>
+        <Area>NVME</Area>
+        <Tags>nvme</Tags>
+        <Priority>0</Priority>
+    </test>
+    <test>
+        <testName>NVME-BLKDISCARD</testName>
+        <testScript>nvme_blkdiscard.sh</testScript>
+        <setupScript>.\Testscripts\Windows\SETUP-Add-NVME-Disk.ps1</setupScript>
+        <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\nvme_blkdiscard.sh</files>
+        <setupType>OneVM</setupType>
+        <OverrideVMSize>Standard_L8s_v2</OverrideVMSize>
+        <testParameters>
+            <param>HYPERV_DISK_COUNT=1</param>
+        </testParameters>
+        <Timeout>3600</Timeout>
         <cleanupScript>.\Testscripts\Windows\SETUP-Remove-NVME-Disk.ps1</cleanupScript>
         <Platform>Azure,HyperV</Platform>
         <Category>Functional</Category>


### PR DESCRIPTION
-nvme-fstrim testcase
-nvme-blkdiscard testcase
-updated timeout for all TCs ( Testcase might timeout before it`s done ) 

**Verification :** 
**Azure :**  

1NVME Drive :

```
[LISAv2 Test Results Summary]
Test Run On           : 01/30/2019 08:28:05
ARM Image Under Test  : Canonical : UbuntuServer : 16.04-LTS : latest
Total Test Cases      : 1 (1 Pass, 0 Fail, 0 Abort)
Total Time (dd:hh:mm) : 0:0:7

   ID TestCaseName                                                                TestResult TestDuration(in minutes) 
---------------------------------------------------------------------------------------------------------------------
    1 NVME-BLKDISCARD                                                                   PASS                  4.3 


[LISAv2 Test Results Summary]
Test Run On           : 01/30/2019 09:25:52
ARM Image Under Test  : Canonical : UbuntuServer : 16.04-LTS : latest
Total Test Cases      : 1 (1 Pass, 0 Fail, 0 Abort)
Total Time (dd:hh:mm) : 0:0:9

   ID TestCaseName                                                                TestResult TestDuration(in minutes) 
---------------------------------------------------------------------------------------------------------------------
    1 NVME-FSTRIM                                                                       PASS                 6.81
 ```
```
[LISAv2 Test Results Summary]
Test Run On           : 01/30/2019 14:13:57
ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : latest
Total Test Cases      : 2 (2 Pass, 0 Fail, 0 Abort)
Total Time (dd:hh:mm) : 0:0:12

   ID TestCaseName                                                                TestResult TestDuration(in minutes) 
---------------------------------------------------------------------------------------------------------------------
    1 NVME-FSTRIM                                                                       PASS                 7.37 
    2 NVME-BLKDISCARD                                                                   PASS                 1.79 
```
8NVME Drives :

```
[LISAv2 Test Results Summary]
Test Run On           : 01/30/2019 09:25:35
ARM Image Under Test  : Canonical : UbuntuServer : 16.04-LTS : latest
Total Test Cases      : 1 (1 Pass, 0 Fail, 0 Abort)
Total Time (dd:hh:mm) : 0:0:23

   ID TestCaseName                                                                TestResult TestDuration(in minutes) 
---------------------------------------------------------------------------------------------------------------------
    1 NVME-BLKDISCARD                                                                   PASS                18.73 

[LISAv2 Test Results Summary]
Test Run On           : 01/30/2019 10:01:27
ARM Image Under Test  : Canonical : UbuntuServer : 16.04-LTS : latest
Total Test Cases      : 1 (1 Pass, 0 Fail, 0 Abort)
Total Time (dd:hh:mm) : 0:0:43

   ID TestCaseName                                                                TestResult TestDuration(in minutes) 
---------------------------------------------------------------------------------------------------------------------
    1 NVME-FSTRIM                                                                       PASS                38.97 
```
```
[LISAv2 Test Results Summary]
Test Run On           : 01/30/2019 17:23:37
ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : latest
Total Test Cases      : 1 (1 Pass, 0 Fail, 0 Abort)
Total Time (dd:hh:mm) : 0:0:43

   ID TestCaseName                                                                TestResult TestDuration(in minutes) 
---------------------------------------------------------------------------------------------------------------------
    1 NVME-FSTRIM                                                                       PASS                38.77 

```
```
[LISAv2 Test Results Summary]
Test Run On           : 01/30/2019 16:25:20
ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : latest
Total Test Cases      : 1 (1 Pass, 0 Fail, 0 Abort)
Total Time (dd:hh:mm) : 0:0:8

   ID TestCaseName                                                                TestResult TestDuration(in minutes) 
---------------------------------------------------------------------------------------------------------------------
    1 NVME-BLKDISCARD                                                                   PASS                  3.8 

```