### PR TITLE
Add new test case for kernel config verify

### DIFF
--- a/Testscripts/Linux/kernel_config_verify_test.sh
+++ b/Testscripts/Linux/kernel_config_verify_test.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache License.
+
+. utils.sh || {
+    echo "unable to source utils.sh!"
+    exit 0
+}
+
+#
+# Source constants file and initialize most common variables
+#
+UtilsInit
+
+# kernel master config file
+declare MasterConfigFile="$LIS_HOME/master.config"
+declare ImageConfigFile="$LIS_HOME/image.config"
+
+# kernel config file diff
+declare ConfigDiffFile="$LIS_HOME/config.diff"
+
+# To extract the image config file
+Extract_image_config()
+{
+	# Check config.gz exists at /proc
+	if [ -f "/proc/config.gz" ]; then
+		LogMsg "the image /proc/config.gz is present"
+		cp /proc/config.gz .
+		gunzip -k config.gz
+		cp config $ImageConfigFile
+	else
+		LogMsg "Error: Image config.gz file is missing or not a regular file!"
+	fi
+
+}
+
+
+# To compare the master config and image config files
+Compare_Kernel_Config()
+{
+	diff $MasterConfigFile $ImageConfigFile > $ConfigDiffFile
+	return $?
+}
+
+#######################################################################
+#
+# Main script body
+#
+#######################################################################
+Extract_image_config
+
+# Check the master and image config file download is present
+if [ -f "$MasterConfigFile" ]; then
+	. "$MasterConfigFile"
+else
+	LogMsg "Error: Master config file $MasterConfigFile missing or not a regular file. Cannot source it!"
+	SetTestStateAborted
+	UpdateSummary "Error: Master config file $MasterConfigFile missing or not a regular file. Cannot source it!"
+	return 3
+fi
+
+if [ -f "$ImageConfigFile" ]; then
+	. "$ImageConfigFile"
+else
+	LogMsg "Error: kernel Image config file $ImageConfigFile missing or not a regular file. Cannot source it!"
+	SetTestStateAborted
+	UpdateSummary "Error: kernel Image config file $ImageConfigFile missing or not a regular file. Cannot source it!"
+	return 3
+fi
+
+Compare_Kernel_Config
+if [ 0 -eq $? ]; then
+    LogMsg "Master and image config files are similar"
+    SetTestStateCompleted
+else
+    LogMsg "Master and image config files are different"
+    SetTestStateFailed
+fi
+

--- a/Testscripts/Windows/KERNEL-CONFIG-VERIFY-TEST.ps1
+++ b/Testscripts/Windows/KERNEL-CONFIG-VERIFY-TEST.ps1
@@ -1,0 +1,87 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache License.
+<#
+.Synopsis
+    Verify the kernel config file.
+
+.Description
+    This script will checks the kernel config file for given image and
+    compare it with master config file.
+
+.Parameter vmName
+    Name of the VM to perform the test with.
+
+.Parameter hvServer
+    Name of the Hyper-V server hosting the VM.
+
+.Parameter testParams
+    A semicolon separated list of test parameters.
+#>
+param([string] $testParams, [object] $AllVmData)
+
+#######################################################################
+#
+# Main script body
+#
+#######################################################################
+function Main {
+    param (
+        $TestParams, $allVMData
+    )
+    $currentTestResult = Create-TestResultObject
+    try{
+        $testResult = $null
+        $masterurl = $TestParams.MasterConfigUrl
+        $captureVMData = $allVMData
+        $hvServer= $captureVMData.HyperVhost
+        $Ipv4 = $captureVMData.PublicIP
+        $VMPort= $captureVMData.SSHPort
+
+        # Change the working directory
+        Set-Location $WorkingDirectory
+
+	# Download the master config file
+        $masterconfigPath =  $WorkingDirectory + ".\" + "master.config"
+        Write-LogInfo "masterurl $masterurl config path: $masterconfigPath"
+
+        $WebClient = New-Object System.Net.WebClient
+        $WebClient.DownloadFile("$masterurl", "$masterconfigPath")
+
+        try {
+            Get-RemoteFileInfo -filename $masterconfigPath  -server $HvServer
+        }
+        catch {
+            Write-LogErr "The .config file $masterconfigPath could not be found!"
+            throw
+        }
+
+        Write-LogInfo "Copy the config files to Remote VM"
+	# remote copy the config files to remote Virtual machine
+        Copy-RemoteFiles -uploadTo $Ipv4 -port $VMPort -files $masterconfigPath -username $user -password $password -upload
+
+	Write-LogInfo "Invoke-Remote script for kernel config validation"
+
+        # Invoke the config verification remote script
+        $remoteScript="kernel_config_verify_test.sh"
+        $retval = Invoke-RemoteScriptAndCheckStateFile $remoteScript $user $password $Ipv4 $VMPort
+        if ($retval -eq $False) {
+            $testResult = "FAIL"
+            throw "Running $remoteScript script failed on VM!"
+        }
+        Write-LogInfo "$remoteScript ran successfully"
+        $testResult = "PASS"
+    } catch {
+        $ErrorMessage =  $_.Exception.Message
+        $ErrorLine = $_.InvocationInfo.ScriptLineNumber
+        Write-LogErr "EXCEPTION : $ErrorMessage at line: $ErrorLine"
+    } finally {
+        if (!$testResult) {
+            $testResult = $resultAborted
+        }
+        $resultArr += $testResult
+    }
+    $currentTestResult.TestResult = Get-FinalResultHeader -resultarr $resultArr
+    return $currentTestResult.TestResult
+}
+
+Main -TestParams  (ConvertFrom-StringData $TestParams.Replace(";","`n")) -allVMData $AllVmData

--- a/XML/Other/ReplaceableTestParameters.xml
+++ b/XML/Other/ReplaceableTestParameters.xml
@@ -183,4 +183,8 @@ Scenario 2 : You need to run all the performance tests quickly.
         <ReplaceThis>OL_VERSIONS_CSV</ReplaceThis>
         <ReplaceWith></ReplaceWith>
     </Parameter>
+    <Parameter>
+        <ReplaceThis>MASTER_KERNEL_CONFIG_URL</ReplaceThis>
+	<ReplaceWith></ReplaceWith>
+    </Parameter>
 </ReplaceableTestParameters>

--- a/XML/TestCases/FunctionalTests-OL.xml
+++ b/XML/TestCases/FunctionalTests-OL.xml
@@ -14,4 +14,18 @@
         <Tags>package</Tags>
         <Priority>0</Priority>
     </test>
+    <test>
+        <TestName>KERNEL-CONFIG-VERIFY-TEST</TestName>
+        <testScript>KERNEL-CONFIG-VERIFY-TEST.ps1</testScript>
+        <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\kernel_config_verify_test.sh</files>
+        <setupType>OneVM</setupType>
+        <TestParameters>
+            <param>MasterConfigUrl=MASTER_KERNEL_CONFIG_URL</param>
+        </TestParameters>
+        <Platform>OL</Platform>
+        <Category>Functional</Category>
+        <Area>OL</Area>
+        <Tags>ol</Tags>
+        <Priority>1</Priority>
+    </test>
 </TestCases>


### PR DESCRIPTION
This test compares the kernel configuration file with master.config stored in blob. 
The latest OL image have config file embedded so modified this PR to support it.

