### PR TITLE
hyperv: reuse failed test case vm

### DIFF
--- a/Libraries/HyperV.psm1
+++ b/Libraries/HyperV.psm1
@@ -609,12 +609,16 @@ function Create-HyperVCheckpoint {
         [string]  $CheckpointName,
         [boolean] $ShouldTurnOffVMBeforeCheckpoint = $true,
         [boolean] $ShouldTurnOnVMAfterCheckpoint = $true,
-        [string]  $CheckpointType = "Standard"
+        [string]  $CheckpointType = "Standard",
+        [switch]  $TurnOff = $true
     )
 
     foreach ($VM in $VMData) {
         if ($ShouldTurnOffVMBeforeCheckpoint) {
-            Stop-VM -Name $VM.RoleName -ComputerName $VM.HyperVHost -TurnOff -Force
+            Stop-VM -Name $VM.RoleName -ComputerName $VM.HyperVHost -TurnOff:$TurnOff -Force:$TurnOff
+            if ($TurnOff) {
+                Wait-VMState -VMName $VM.RoleName -HvServer $VM.HyperVHost -VMState "Off"
+            }
         } else {
             Start-VM -Name $VM.RoleName -ComputerName $VM.HyperVHost
         }

--- a/Libraries/HyperV.psm1
+++ b/Libraries/HyperV.psm1
@@ -610,12 +610,12 @@ function Create-HyperVCheckpoint {
         [boolean] $ShouldTurnOffVMBeforeCheckpoint = $true,
         [boolean] $ShouldTurnOnVMAfterCheckpoint = $true,
         [string]  $CheckpointType = "Standard",
-        [switch]  $TurnOff = $true
+        [boolean] $TurnOff = $true
     )
 
     foreach ($VM in $VMData) {
         if ($ShouldTurnOffVMBeforeCheckpoint) {
-            Stop-VM -Name $VM.RoleName -ComputerName $VM.HyperVHost -TurnOff:$TurnOff -Force:$TurnOff
+            Stop-VM -Name $VM.RoleName -ComputerName $VM.HyperVHost -TurnOff:$TurnOff -Force
             if ($TurnOff) {
                 Wait-VMState -VMName $VM.RoleName -HvServer $VM.HyperVHost -VMState "Off"
             }
@@ -721,24 +721,24 @@ function Check-IP {
 }
 
 function Wait-VMState {
-    param(
-        $VMName,
-        $VMState,
-        $HvServer,
-        $RetryCount=30,
-        $RetryInterval=5
-    )
+	param(
+		$VMName,
+		$VMState,
+		$HvServer,
+		$RetryCount=30,
+		$RetryInterval=5
+	)
 
-    $currentRetryCount = 0
-    while ($currentRetryCount -lt $RetryCount -and `
-                (Get-VM -ComputerName $HvServer -Name $VMName).State -ne $VMState) {
-        Write-LogInfo "Waiting for VM ${VMName} to enter ${VMState} state"
-        Start-Sleep -Seconds $RetryInterval
-        $currentRetryCount++
-    }
-    if ($currentRetryCount -eq $RetryCount) {
-        throw "VM ${VMName} failed to enter ${VMState} state"
-    }
+	$currentRetryCount = 0
+	while ($currentRetryCount -lt $RetryCount -and `
+			(Get-VM -ComputerName $HvServer -Name $VMName).State -ne $VMState) {
+		Write-LogInfo "Waiting for VM ${VMName} to enter ${VMState} state"
+		Start-Sleep -Seconds $RetryInterval
+		$currentRetryCount++
+	}
+	if ($currentRetryCount -eq $RetryCount) {
+		throw "VM ${VMName} failed to enter ${VMState} state"
+	}
 }
 
 function Wait-VMStatus {

--- a/TestProviders/HyperVProvider.psm1
+++ b/TestProviders/HyperVProvider.psm1
@@ -68,7 +68,7 @@ Class HyperVProvider : TestProvider
 				}
 
 				Inject-HostnamesInHyperVVMs -allVMData $allVMData
-				Create-HyperVCheckpoint -VMData $AllVMData -CheckpointName $this.BaseCheckpoint -TurnOff:$false
+				Create-HyperVCheckpoint -VMData $AllVMData -CheckpointName $this.BaseCheckpoint -TurnOff $false
 
 				if ((Test-Path -Path  .\Extras\UploadDeploymentDataToDB.ps1) -and !$UseExistingRG) {
 					.\Extras\UploadDeploymentDataToDB.ps1 -allVMData $allVMData -DeploymentTime $DeploymentElapsedTime.TotalSeconds
@@ -98,6 +98,7 @@ Class HyperVProvider : TestProvider
 
 	[void] RunSetup($VmData, $CurrentTestData, $TestParameters, $ApplyCheckPoint) {
 		if ($CurrentTestData.AdditionalHWConfig.HyperVApplyCheckpoint -eq "False") {
+			$VmData = Check-IP -VMData $VmData
 			Remove-AllFilesFromHomeDirectory -allDeployedVMs $VmData
 			Write-LogInfo "Removed all files from home directory."
 		} elseif ($ApplyCheckPoint) {

--- a/TestProviders/HyperVProvider.psm1
+++ b/TestProviders/HyperVProvider.psm1
@@ -75,7 +75,7 @@ Class HyperVProvider : TestProvider
 				}
 
 				# Create the initial checkpoint
-				Create-HyperVCheckpoint -VMData $AllVMData -CheckpointName $this.BaseCheckpoint
+				Create-HyperVCheckpoint -VMData $AllVMData -CheckpointName $this.BaseCheckpoint -TurnOff:$false
 				$allVMData = Check-IP -VMData $AllVMData
 			}
 			else

--- a/TestProviders/TestProvider.psm1
+++ b/TestProviders/TestProvider.psm1
@@ -30,6 +30,7 @@ Class TestProvider
 {
 	[string] $CustomKernel
 	[string] $CustomLIS
+	[bool]   $ReuseVmOnFailure = $false
 
 	[object] DeployVMs([xml] $GlobalConfig, [object] $SetupTypeData, [object] $TestCaseData, [string] $TestLocation, [string] $RGIdentifier, [bool] $UseExistingRG) {
 		return $null


### PR DESCRIPTION
The refactor removed snapshot usage on Hyper-V.

This patch brings back the snapshot feature usage in Hyper-V.

On HyperV platform, the VMs are reused for each test case that asks for the same VM setup type in order to decrease resource consumption.

General workflow (changes of this patch are in bold):

1. create vm
2. create checkpoint icabase for that vm
3. first test case is run on the vm
4. **if the first test case fails, create a checkpoint for the failed state.**
5. **apply icabase checkpoint**
6. second test case is run on the same vm, etc.

Fixes #599 