### PR TITLE
Code Coverage: Added code coverage feature

### DIFF
--- a/LISAv2-Framework.psm1
+++ b/LISAv2-Framework.psm1
@@ -38,6 +38,9 @@ function Start-LISAv2 {
 		[string] $TestNames="",
 		[string] $TestPriority="",
 
+		# [Optional] Enable kernel code coverage
+		[switch] $EnableCodeCoverage,
+
 		# [Optional] Parameters for Image preparation before running tests.
 		[string] $CustomKernel = "",
 		[string] $CustomLIS,

--- a/Run-LisaV2.ps1
+++ b/Run-LisaV2.ps1
@@ -54,6 +54,9 @@ Param(
 	[string] $TestNames="",
 	[string] $TestPriority="",
 
+	# [Optional] Enable kernel code coverage
+	[switch] $EnableCodeCoverage,
+
 	# [Optional] Parameters for Image preparation before running tests.
 	[string] $CustomKernel = "",
 	[string] $CustomLIS,

--- a/TestControllers/TestController.psm1
+++ b/TestControllers/TestController.psm1
@@ -70,6 +70,7 @@ Class TestController
 	[bool] $UseExistingRG
 	[array] $TestCaseStatus
 	[array] $TestCasePassStatus
+	[bool] $EnableCodeCoverage
 
 	[string[]] ParseAndValidateParameters([Hashtable]$ParamTable) {
 		$this.TestLocation = $ParamTable["TestLocation"]
@@ -91,6 +92,7 @@ Class TestController
 		$this.ResultDBTable = $ParamTable["ResultDBTable"]
 		$this.ResultDBTestTag = $ParamTable["ResultDBTestTag"]
 		$this.UseExistingRG = $ParamTable["UseExistingRG"]
+		$this.EnableCodeCoverage = $ParamTable["EnableCodeCoverage"]
 
 		$this.TestProvider.CustomKernel = $ParamTable["CustomKernel"]
 		$this.TestProvider.CustomLIS = $ParamTable["CustomLIS"]
@@ -192,6 +194,7 @@ Class TestController
 
 		$allTests = Collect-TestCases -TestXMLs $TestXMLs -TestCategory $this.TestCategory -TestArea $this.TestArea `
 			-TestNames $this.TestNames -TestTag $this.TestTag -TestPriority $this.TestPriority
+
 		if( !$allTests ) {
 			Throw "Not able to collect any test cases from XML files"
 		} else {
@@ -433,7 +436,7 @@ Class TestController
 
 		# Do log collecting and VM clean up
 		if (!$this.IsWindows -and $testParameters["SkipVerifyKernelLogs"] -ne "True") {
-			GetAndCheck-KernelLogs -allDeployedVMs $VmData -status "Final" | Out-Null
+			GetAndCheck-KernelLogs -allDeployedVMs $VmData -status "Final" -EnableCodeCoverage $this.EnableCodeCoverage | Out-Null
 			Get-SystemBasicLogs -AllVMData $VmData -User $global:user -Password $global:password -CurrentTestData $CurrentTestData `
 				-CurrentTestResult $currentTestResult -enableTelemetry $this.EnableTelemetry
 		}

--- a/Testscripts/Linux/build_gcov_kernel.sh
+++ b/Testscripts/Linux/build_gcov_kernel.sh
@@ -1,0 +1,197 @@
+#!/bin/bash
+
+RESULTS="$(readlink -f ./results.txt)"
+
+function report_result {
+    echo "$1" > $RESULTS
+}
+
+function report_error {
+    exit_code="$1"
+    
+    if [ $exit_code -ne 0 ];then
+        report_result "$2"
+        exit 0
+    fi
+}
+
+. constants.sh || {
+    report_result "NO_CONSTANTS"
+}
+
+set -x
+
+function install_ubuntu_deps {
+    apt -y update
+    DEBIAN_FRONTEND=noninteractive apt install -y build-essential flex bison kernel-package libncurses-dev libelf-dev libssl-dev bzip2 git
+    report_error $? "INSTALL_DEPS_ERROR"
+}
+
+function get_sources_from_git {
+    git_url="$1"
+    source_dest="$(readlink -f $2)"
+    
+    if [[ -d "$source_dest" ]];then
+        rm -rf $source_dest
+    fi
+    
+    git clone $git_url $source_dest
+    report_error $? "GIT_CLONE_ERROR"
+}
+
+function get_sources_from_package {
+    package_path="$(readlink -f $1)"
+    source_dest="$(readlink -f $2)"
+
+    work_dir=$(readlink -f ./temp)
+
+    if [[ -d "$source_dest" ]];then
+            rm -rf $source_dest
+    fi
+    mkdir -p "$source_dest"
+
+    if [[ -d "$work_dir" ]];then
+            rm -rf $work_dir
+    fi
+    mkdir -p $work_dir
+
+    pushd $work_dir
+    dpkg -x $package_path .
+    report_error $? "DEB_EXTRACT_ERROR"
+    
+    archive_path=$(find . -name "linux-source*.bz2" | head -n 1)
+    if [[ ! -e $archive_path ]];then
+        report_error 1 "WRONG_PACKAGE_ERROR"
+    fi
+
+    mkdir sources
+    bzip2 -dc $archive_path | tar xvf - -C ./sources
+    mv ./sources/linux-source*/* $source_dest
+    popd
+}
+
+function config_kernel {
+    build_dir="$1"
+    config_url="$2"
+    
+    pushd "$build_dir"
+    make mrproper
+    if [[ $config_url != "" ]];then
+        wget $config_url -O new-config
+        cp new-config .config
+    fi
+    make olddefconfig
+    
+    new_lines="CONFIG_CONSTRUCTORS=y\nCONFIG_GCOV_KERNEL=y\nCONFIG_GCOV_PROFILE_ALL=y\nCONFIG_GCOV_FORMAT_4_7=y\n# CONFIG_GCOV_PROFILE_FTRACE is not set"
+    sed -i "s/# CONFIG_GCOV_KERNEL is not set/$new_lines/" .config
+    popd
+}
+
+function build_kernel {
+    build_dir="$1"
+
+    pushd "$build_dir"
+    make-kpkg --initrd -j"$(($(nproc) * 5))" kernel_image kernel_headers kernel_source
+    report_error $? "KERNEL_BUILD_ERROR"
+    popd
+}
+
+function collect_sources {
+    KSRC=$1
+    KOBJ=$2
+    DEST=$3
+
+    if [ -z "$KSRC" ] || [ -z "$KOBJ" ] || [ -z "$DEST" ]; then
+        echo "Usage: $0 <ksrc directory> <kobj directory> <output.tar.gz>" >&2
+        exit 1
+    fi
+
+    KSRC=$(cd $KSRC; printf "all:\n\t@echo \${CURDIR}\n" | make -f -)
+    KOBJ=$(cd $KOBJ; printf "all:\n\t@echo \${CURDIR}\n" | make -f -)
+
+    find $KSRC $KOBJ \( -name '*.gcno' -o -name '*.[ch]' -o -type l \) -a \
+                     -perm /u+r,g+r | tar cfz $DEST -P -T -
+
+    report_error $? "SOURCE_COLLECT_ERROR"
+}
+
+function archive_artifacts {
+    build_dir="$1"
+    packages_dest="$2"
+    source_dest="$3"
+    
+    parent_dir=$(dirname $build_dir)
+    
+    pushd "$parent_dir"
+    if [[ ! $(find *.deb) ]];then
+        echo "Cannot find kernel packages"
+        exit 0
+    fi
+    tar cvf packages.tar *.deb
+    cp packages.tar $packages_dest
+    popd
+    
+    collect_sources "$build_dir" "$build_dir" "$source_dest"
+}
+
+function main {
+    while true;do
+        case "$1" in
+            --build_dir)
+                BUILD_DIR=$2
+                shift 2;;
+            --source_dest)
+                SOURCE_DEST=$(readlink -f $2) 
+                shift 2;;
+            --packages_dest)
+                PACKAGE_DEST=$(readlink -f $2) 
+                shift 2;;
+            --git_repo)
+                GIT_REPO=$2 
+                shift 2;;
+            --package_path)
+                PACKAGE_NAME="$2"
+                shift 2;;
+            --custom_config_url)
+                CONFIG_URL=$2 
+                shift 2;;
+            --) shift; break ;;
+            *) break ;;
+        esac
+    done
+    
+    PACKAGE_PATH="$(PACKAGE_NAME=${PACKAGE_NAME##*\\}; echo ${PACKAGE_NAME##*/})"
+
+    if [[ "$BUILD_DIR" == "" ]];then
+        exit 0
+    fi
+    if [[ -d "$BUILD_DIR" ]];then
+            rm -rf $BUILD_DIR
+    fi
+    mkdir -p $BUILD_DIR
+    
+    install_ubuntu_deps
+
+    if [[ $PACKAGE_PATH != "" ]];then
+        get_sources_from_package $PACKAGE_PATH $BUILD_DIR
+    elif [[ $GIT_REPO != "" ]];then
+        get_sources_from_git $GIT_REPO $BUILD_DIR
+    fi
+
+    config_kernel $BUILD_DIR $CONFIG_URL
+    build_kernel $BUILD_DIR
+    
+    archive_artifacts $BUILD_DIR $PACKAGE_DEST $SOURCE_DEST
+    
+    if [[ ! -e $PACKAGE_DEST ]] || [[ ! -e $SOURCE_DEST ]];then
+       report_error 1 "ARTIFACTS_MISSING_ERROR"
+    else 
+       report_result "BUILD_SUCCEDED"
+    fi
+    
+    exit 0
+}
+
+main --build_dir $BUILD_DIR --source_dest $SOURCE_DEST \
+     --packages_dest $PACKAGE_DEST --package_path $SRC_PACKAGE_NAME \
+     --custom_config_url $CONFIG_URL

--- a/Testscripts/Linux/collect_gcov_data.sh
+++ b/Testscripts/Linux/collect_gcov_data.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+GCDA=/sys/kernel/debug/gcov
+
+while true;do
+    case "$1" in
+        --dest)
+            DEST=$(readlink -f $2)
+            shift 2;;
+        --result)
+            RESULT=$(readlink -f $2) 
+            shift 2;;
+        --) shift; break ;;
+        *) break ;;
+    esac
+done
+
+echo "GCOV_MISSING" > $RESULT
+
+if [ -z "$DEST" ] ; then
+    echo "Missing destination parameter"
+    echo "PARAM_MISSING" > $RESULT
+    exit 0
+fi
+
+TEMPDIR=$(mktemp -d)
+find $GCDA -type d -exec mkdir -p $TEMPDIR/\{\} \;
+find $GCDA -name '*.gcda' -exec sh -c 'cat < $0 > '$TEMPDIR'/$0' {} \;
+find $GCDA -name '*.gcno' -exec sh -c 'cp -d $0 '$TEMPDIR'/$0' {} \;
+tar czf $DEST -C $TEMPDIR sys
+rm -rf $TEMPDIR
+
+echo "GCOV_COLLECTED" > $RESULT
+exit 0

--- a/Testscripts/Linux/generate_gcov.sh
+++ b/Testscripts/Linux/generate_gcov.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache License.
+
+CORE_FILES=('drivers/hv/channel.c' 'drivers/hv/channel_mgmt.c' 'drivers/hv/connection.c'
+               'drivers/hid/hid-core.c' 'drivers/hid/hid-debug.c' 'drivers/hid/hid-hyperv.c'
+               'drivers/hid/hid-input.c' 'drivers/hid/hv.c' 'drivers/hv/hv_balloon.c'
+               'drivers/hv/hv_compat.c' 'drivers/hv/hv_fcopy.c' 'drivers/hv/hv_kvp.c'
+               'drivers/hv/hv_snapshot.c' 'drivers/hv/hv_util.c' 'drivers/hv/hv_utils_transport.c'
+               'drivers/input/serio/hyperv-keyboard.c' 'drivers/video/fbdev/hyperv_fb.c'
+               'drivers/net/hyperv/netvsc.c' 'drivers/net/hyperv/netvsc_drv.c'
+               'drivers/hv/ring_buffer.c' 'drivers/net/hyperv/rndis_filter.c'
+               'drivers/scsi/storvsc_drv.c' 'drivers/hv/vmbus_drv.c')
+
+HV_SOCK_FILES=('drivers/hv/channel.c' 'drivers/hv/channel_mgmt.c' 'drivers/hv/connection.c'
+                'drivers/hv/hv_util.c' 'drivers/hv/hv_utils_transport.c' 'drivers/hv/vmbus_drv.c'
+                'net/vmw_vsock/af_vsock.c')
+                
+SRIOV_FILES=('drivers/net/ethernet/mellanox/mlx4/alloc.c' 'drivers/net/ethernet/mellanox/mlx4/catas.c'
+             'drivers/net/ethernet/mellanox/mlx4/cmd.c' 'drivers/net/ethernet/mellanox/mlx4/cq.c'
+             'drivers/net/ethernet/mellanox/mlx4/eq.c' 'drivers/net/ethernet/mellanox/mlx4/fw.c'
+             'drivers/net/ethernet/mellanox/mlx4/fw_qos.c' 'drivers/net/ethernet/mellanox/mlx4/icm.c'
+             'drivers/net/ethernet/mellanox/mlx4/intf.c' 'drivers/net/ethernet/mellanox/mlx4/main.c'
+             'drivers/net/ethernet/mellanox/mlx4/mcg.c' 'drivers/net/ethernet/mellanox/mlx4/mr.c'
+             'drivers/net/ethernet/mellanox/mlx4/pd.c' 'drivers/net/ethernet/mellanox/mlx4/port.c'
+             'drivers/net/ethernet/mellanox/mlx4/profile.c' 'drivers/net/ethernet/mellanox/mlx4/qp.c'
+             'drivers/net/ethernet/mellanox/mlx4/reset.c' 'drivers/net/ethernet/mellanox/mlx4/sense.c'
+             'drivers/net/ethernet/mellanox/mlx4/srq.c' 'drivers/net/ethernet/mellanox/mlx4/resource_tracker.c'
+             'drivers/net/ethernet/mellanox/mlx4/en_main.c' 'drivers/net/ethernet/mellanox/mlx4/en_tx.c'
+             'drivers/net/ethernet/mellanox/mlx4/en_rx.c' 'drivers/net/ethernet/mellanox/mlx4/en_ethtool.c'
+             'drivers/net/ethernet/mellanox/mlx4/en_port.c' 'drivers/net/ethernet/mellanox/mlx4/en_cq.c'
+             'drivers/net/ethernet/mellanox/mlx4/en_resources.c' 'drivers/net/ethernet/mellanox/mlx4/en_netdev.c'
+             'drivers/net/ethernet/mellanox/mlx4/en_selftest.c' 'drivers/net/ethernet/mellanox/mlx4/en_clock.c')
+               
+LOG_REL_PATH="/sys/kernel/debug/gcov/"
+
+function generate_file_list {
+    test_category="$1"
+    
+    if [[ $test_category == "sriov" ]];then
+        COLLECT_FILES=${SRIOV_FILES[@]}
+    elif [[ $test_category == "hv-sock" ]];then
+        COLLECT_FILES=${HV_SOCK_FILES[@]}
+    else
+        COLLECT_FILES=${CORE_FILES[@]}
+    fi
+}
+
+function install_packages {
+    apt -y update
+    apt -y install gcc
+}
+
+function generate_gcov {
+    source_dir=$1
+    logs_dir=$2
+    dest_dir=$3
+    file=$4
+    
+    file_name=$(basename $file)
+    
+    pushd "$source_dir"
+    if [[ ! -e $file ]];then
+        echo "Cannot find specified file: $file"
+        popd
+        return 0
+    fi
+    
+    log_rel_dir="${file%/*}"
+    logs_dir=$(readlink -f "${logs_dir}/${log_rel_dir}")
+    if [[ ! -e $logs_dir ]];then
+        echo "Cannot find the relative path to the log file"
+        popd
+        return 0
+    fi
+    
+    gcov -o "$logs_dir" "$file"
+    if [[ ! -e "${file_name}.gcov" ]];then
+        echo "Cannot find gcov report for file: $file"
+        popd
+        return 0
+    fi
+    cp "${file_name}.gcov" $dest_dir
+    
+    popd
+}
+
+function main {
+    while true;do
+        case "$1" in
+            --build_dir)
+                BUILD_DIR=$2
+                shift 2;;
+            --test_category)
+                TEST_CATEGORY=$2
+                shift 2;;
+            --test_name)
+                TEST_NAME=$2
+                shift 2;;
+            --work_dir)
+                WORK_DIR=$2
+                shift 2;;
+            --archive_name)
+                ARCHIVE_NAME=$2
+                shift 2;;
+            --) shift; break ;;
+            *) break ;;
+        esac
+    done
+    
+    if [[ ! -d "${WORK_DIR}" ]];then
+        mkdir -p "${WORK_DIR}"
+    fi
+    
+    # Install packages
+    install_packages
+    
+    # Generate SOURCE_DIR
+    if [[ -e "${BUILD_DIR}" ]];then
+        SOURCE_DIR="${BUILD_DIR}"
+    else 
+        echo "Cannot find sources directory"
+        exit 0
+    fi
+    
+    # Generate LOGS_DIR
+    LOGS_DIR="${WORK_DIR}/logs/${TEST_NAME}"
+    if [[ -e "$LOGS_DIR" ]];then
+        rm -rf "$LOGS_DIR"
+    fi
+    mkdir -p "$LOGS_DIR"
+    if [[ -e "$ARCHIVE_NAME" ]];then
+        tar xzf "$ARCHIVE_NAME" -C "$LOGS_DIR"
+    else
+        echo "Cannot find logs archive"
+        exit 0
+    fi
+    LOGS_DIR="${LOGS_DIR}/${LOG_REL_PATH}/${BUILD_DIR}"
+    LOGS_DIR="$(readlink -f $LOGS_DIR)"
+    if [[ ! -d "${LOGS_DIR}" ]];then
+        echo "Cannot find final log directory"
+        exit 0
+    fi
+    
+    # Generate DEST_DIR
+    DEST_DIR="${WORK_DIR}/gcov/${TEST_NAME}"
+    if [[ -e "$DEST_DIR" ]];then
+        rm -rf "$DEST_DIR"
+    fi
+    mkdir -p $DEST_DIR
+    
+    generate_file_list $TEST_CATEGORY
+    
+    # Working with SOURCE_DIR, LOGS_DIR, DEST_DIR
+    for file in ${COLLECT_FILES[@]};do
+        generate_gcov $SOURCE_DIR $LOGS_DIR $DEST_DIR $file
+    done
+}
+
+main $@

--- a/Testscripts/Linux/generate_gcov_report.sh
+++ b/Testscripts/Linux/generate_gcov_report.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache License.
+
+function install_packages {
+    apt -y update 
+    apt install -y python-pip zip
+    pip install gcovr
+}
+
+function main {
+    while true;do
+        case "$1" in
+            --build_dir)
+                BUILD_DIR=$2
+                shift 2;;
+            --test_category)
+                TEST_CATEGORY=$2
+                shift 2;;
+            --gcov_path)
+                GCOV_PATH=$2
+                shift 2;;
+            --) shift; break ;;
+            *) break ;;
+        esac
+    done
+    
+    WORK_DIR=$(readlink -f .)
+    
+    install_packages
+    
+    if [[ ! -e "${BUILD_DIR}" ]];then
+        echo "Cannot find sources directory"
+        exit 0
+    fi
+    
+    if [[ ! -e "${GCOV_PATH}" ]];then
+        echo "Cannot find sources directory"
+        exit 0
+    fi
+    
+    pushd $BUILD_DIR
+    rm *.gcov
+    mv $GCOV_PATH .
+    gcovr -g -k --html --html-details -o ./${TEST_CATEGORY}.html -v --exclude-directories debian
+    zip "${TEST_CATEGORY}.zip" *.html
+    cp "${TEST_CATEGORY}.zip" $WORK_DIR
+    popd
+}
+
+main $@

--- a/Testscripts/Windows/Build-GcovKernel.ps1
+++ b/Testscripts/Windows/Build-GcovKernel.ps1
@@ -1,0 +1,71 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache License.
+
+param([String] $TestParams, [object] $AllVmData)
+
+$testScript = "build_gcov_kernel.sh"
+
+function Main() {
+    $publicIP = $AllVMData.PublicIP
+    $port = $AllVMData.SSHPort
+    $currentTestResult = Create-TestResultObject
+    $testResult = "Aborted"
+
+    $params = @{}
+    $TestParams.Split(";") | ForEach-Object {
+        $arg = $_.Split("=")[0]
+        $val = $_.Split("=")[1]
+        $params[$arg] = $val
+    }
+
+    $sourceDest = $params["SOURCE_DEST"]
+    $packageDest = $params["PACKAGE_DEST"]
+    if (( -not $sourceDest) -and ( -not $packageDest)) {
+        Write-LogErr "Cannot find destination parameters"
+        $currentTestResult.TestResult = Get-FinalResultHeader -resultarr $testResult
+        return $currentTestResult
+    }
+    $srcLocalUrl = $params["SRC_PACKAGE_PATH"]
+    $srcLocalUrl = Resolve-Path $srcLocalUrl
+    Write-LogInfo "PATH: $srcLocalUrl"
+
+    $srcLocalUrl = Resolve-Path $srcLocalUrl
+    if ( -not (Test-Path $srcLocalUrl)) {
+        Write-LogErr "Cannot find local source package in path: $srcLocalUrl"
+        $currentTestResult.TestResult = Get-FinalResultHeader -resultarr $testResult
+        return $currentTestResult
+    }
+
+    Copy-RemoteFiles -uploadTo $publicIP -port $port -username $username -password $password -upload `
+        -files "$srcLocalUrl"
+
+    $null = Run-LinuxCmd -username $user -password $password `
+        -ip $publicIP -port $port -command "chmod a+x *.sh" -runAsSudo
+    $null = Run-LinuxCmd -username $username -runMaxAllowedTime 6000 `
+        -password $password -ip $publicIP -port $port `
+        -command "bash /home/$username/${testScript} > debug.log 2>&1" -runAsSudo
+
+    $buildResult = Run-LinuxCmd -username $user -password $password `
+        -ip $publicIP -port $port -command "cat ./results.txt" -runAsSudo
+    Write-LogInfo "Build result: $buildResult"
+    if ($buildResult -NotMatch "BUILD_SUCCEDED") {
+        $currentTestResult.TestResult = Get-FinalResultHeader -resultarr $testResult
+        return $currentTestResult
+    }
+
+    if (Test-Path ".\CodeCoverage") {
+        Remove-Item -Path ".\CodeCoverage" -Recurse -Force
+    }
+    New-Item -Type directory -Path ".\CodeCoverage\artifacts"
+
+    Copy-RemoteFiles -download -downloadFrom $publicIP -files "${sourceDest},${packageDest}" `
+        -downloadTo ".\CodeCoverage\artifacts" -port $port -username $username -password $password
+
+    $testResult = "PASS"
+    Write-LogInfo "Code coverage artifacts successfully downloaded in dir: CodeCoverage\artifacts"
+
+    $currentTestResult.TestResult = Get-FinalResultHeader -resultarr $testResult
+    return $currentTestResult
+}
+
+Main

--- a/Testscripts/Windows/Get-GcovReport.ps1
+++ b/Testscripts/Windows/Get-GcovReport.ps1
@@ -1,0 +1,66 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache License.
+
+param([String] $TestParams, [object] $AllVmData)
+
+$gcovScript = "generate_gcov.sh"
+$reportScript = "generate_gcov_report.sh"
+
+$WORK_DIR = "/reporting"
+
+function Main() {
+    $publicIP = $AllVMData.PublicIP
+    $port = $AllVMData.SSHPort
+    $currentTestResult = Create-TestResultObject
+
+    $params = @{}
+    $TestParams.Split(";") | ForEach-Object {
+        $arg = $_.Split("=")[0]
+        $val = $_.Split("=")[1]
+		# Debug
+		Write-LogInfo "ARG: $arg , VAL: $val"
+
+        $params[$arg] = $val
+    }
+
+	$remoteBuildDir = $params["BUILD_DIR"]
+	$logsPath = $params["LOCAL_LOGS_PATH"]
+	$testCategory = $params["TEST_CATEGORY"]
+
+	$sourcesPath = $params["LOCAL_SRC_PATH"]
+	$sourcesPath = Resolve-Path $sourcesPath
+	if ( -not (Test-Path $sourcesPath)) {
+		Write-LogErr "Cannot find sources archive"
+		throw "sources doesn't exist"
+	}
+	$sourcesName = Split-Path $sourcesPath -Leaf
+	Copy-RemoteFiles -uploadTo $publicIP -port $port -username $username -password $password -upload `
+        -files "$sourcesPath"
+	$null = Run-LinuxCmd -username $user -password $password `
+        -ip $publicIP -port $port -runAsSudo `
+		-command "tar xzf ${sourcesName} -C /"
+
+	Get-ChildItem -Recurse -Path $logsPath -Include "gcov*.gz" | ForEach-Object {
+		$fullPath = $_.FullName
+		$logName = $_.Name
+		$testName = $_.Directory.Name
+
+		Copy-RemoteFiles -uploadTo $publicIP -port $port -username $username -password $password -upload `
+			-files "$fullPath"
+		$null = Run-LinuxCmd -username $user -password $password `
+			-ip $publicIP -port $port -runAsSudo `
+			-command "bash /home/$username/${gcovScript} --test_category ${testCategory} --test_name ${testName} --work_dir ${WORK_DIR} --build_dir ${remoteBuildDir} --archive_name ${logName}"
+	}
+
+    $null = Run-LinuxCmd -username $user -password $password `
+        -ip $publicIP -port $port -runAsSudo `
+        -command "bash /home/$username/${reportScript} --build_dir ${remoteBuildDir} --test_category ${testCategory} --gcov_path ${WORK_DIR}/gcov"
+
+    Copy-RemoteFiles -download -downloadFrom $publicIP -files "${testCategory}.zip" `
+        -downloadTo ".\CodeCoverage\" -port $port -username $username -password $password
+
+    $currentTestResult.TestResult = Get-FinalResultHeader -resultarr "PASS"
+    return $currentTestResult
+}
+
+Main

--- a/Utilities/CodeCoverage/Upload-Report.ps1
+++ b/Utilities/CodeCoverage/Upload-Report.ps1
@@ -1,0 +1,98 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache License.
+param(
+    [String] $FTPHost,
+    [String] $FTPUser,
+    [String] $FTPPass,
+    [String] $SourceFolder,
+    [String] $KernelName,
+    [String] $Url
+)
+
+$CURRENT_DIR = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+function Sync-Files {
+    param(
+        [string] $Username,
+        [string] $Password,
+        [String] $Hostname,
+        [String] $SrcPath,
+        [String] $DesPath
+    )
+
+    $chknuget = Get-PackageProvider -Name NuGet  -ErrorAction SilentlyContinue
+    $ckwinscp = Get-InstalledModule -Name WinSCP  -ErrorAction SilentlyContinue
+    if (-not $chknuget) {
+        Write-Host "Instaling PackageProvider Nuget ..."
+        $innuget = Install-PackageProvider -Name NuGet -Force
+        if (-not $innuget) {
+            Write-Error "Failed to install PackageProvider Nuget..."
+        }
+    }
+    if (-not $ckwinscp) {
+        Write-Host "Instaling WinSCP Powershell Wrapper..."
+        $inwinscp = Install-Module -Name WinSCP  -Force
+        if (-not $inwinscp) {
+            Write-Error "Failed to install WinSCP Powershell Wrapper..."
+        }
+    }
+
+    #Start
+    Write-Host "Starting Connection to $Hostname ..."
+    # Creating Credentials
+    $secPass = $Password | ConvertTo-SecureString -AsPlainText -Force
+    $Credential = New-Object System.Management.Automation.PSCredential -ArgumentList $Username, $secPass
+    $Session = New-WinSCPSessionOption -HostName $Hostname -Credential $Credential -Protocol Ftp
+    # Connect
+    $Connection = New-WinSCPSession -SessionOption $Session
+    if (-not $Connection) {
+        Write-Host "Failed to Connect to $Hostname ..."
+    }
+    Write-Host "SRC: $SrcPath  DEST: $DesPath"
+    $move = Send-WinSCPItem  -WinSCPSession $Connection  -Path $SrcPath -Destination $DesPath
+    # Force param  will create directory
+    if (-not $move) {
+        Write-Error "Failed to preform FTP operation..."
+    }
+    # Remove the WinSCPSession after completion.
+    Remove-WinSCPSession -WinSCPSession $Connection -ErrorAction SilentlyContinue
+}
+
+function Update-Coverage {
+    param(
+        [String] $SrcPath,
+        [String] $Htmlloc,
+        [String] $KernelName
+    )
+    Write-Host "Parsing coverage  ..."
+    $fixfile = Get-Content "$SrcPath"; $fixfile[0] = "{"; $fixfile[-1] = "}"; $fixfile |Out-File "temp.js" -Encoding 'ASCII'
+    if (!$fixfile) {
+        Write-Error "Failed to change Encoding to UTF-8..."
+    }
+    #Python Should installed by default
+    & "C:\Python27\python.exe" .\create_coverage_file.py "temp.js" $Htmlloc  "$KernelName" > $SrcPath
+
+}
+
+Function Main {
+
+    Write-Host "Uploading files to date directory ..."
+    $SrcDest = $(Get-ChildItem -Path "$SourceFolder"| Sort-Object LastAccessTime -Descending | Select-Object -First 1).Name
+    $SrcPathD = $(Get-ChildItem -Path "$SourceFolder"| Sort-Object LastAccessTime -Descending | Select-Object -First 1).FullName
+
+    Copy-Item -Path $SrcPathD -Destination $SrcDest -Recurse
+
+    Sync-Files -Username $FTPUser -Password $FTPPass -Hostname $FTPHost -SrcPath "${CURRENT_DIR}\${SrcDest}" -DesPath "/site/wwwroot/pages/$SrcDest"
+
+    Write-Host "Downloading coverage data file..."
+    New-Item -Name "js" -ItemType directory
+    Invoke-WebRequest -Uri "$Url" -OutFile "./js/pageData.js"
+
+    #Parsing coverage
+    Update-Coverage -SrcPath "${CURRENT_DIR}\js\pageData.js" -Htmlloc $SrcDest  -KernelName $KernelName
+    Sync-Files -Username $FTPUser -Password $FTPPass -Hostname $FTPHost -SrcPath "${CURRENT_DIR}\js\pageData.js" -DesPath "/site/wwwroot/js/pageData.js"
+
+    Write-Host "###Done####"
+}
+
+Main

--- a/Utilities/CodeCoverage/create_coverage_file.py
+++ b/Utilities/CodeCoverage/create_coverage_file.py
@@ -1,0 +1,92 @@
+import collections
+import os
+import sys
+from HTMLParser import HTMLParser
+from collections import defaultdict
+import json
+
+
+class CoverageParser(HTMLParser):
+    def __init__(self):
+        HTMLParser.__init__(self)
+        self.values = []
+        self.found_value = False
+
+    def handle_starttag(self, tag, attrs):
+        if tag == 'td':
+            for attr_name, attr_value in attrs:
+                if attr_name == 'class' and attr_value == 'headerTableEntry':
+                    self.found_value = True
+    
+    def handle_data(self, data):
+        if self.found_value:
+            self.values.append(data)
+            self.found_value = False
+
+    def get_coverage_value(self):
+        for value in self.values:
+            if '%' in value:
+                return value.strip('%').strip()
+
+
+def get_coverage_value(html_path):
+    with open(html_path, 'r') as html_content:
+        parser = CoverageParser()
+        parser.feed(html_content.read())
+        return parser.get_coverage_value()
+
+
+def main(results_path):
+    coverage_map = {
+        'runDate': {},
+        'testArea': {},
+        'latestRuns': {}
+    }
+
+    coverage_values = defaultdict(dict)
+
+    time_dirs = os.listdir(results_path)
+    for time_dir in time_dirs:
+        area_dirs = os.listdir(os.path.join(results_path, time_dir))
+        for area_dir in area_dirs:
+            coverage_value = get_coverage_value(os.path.join(results_path, time_dir, area_dir, '%s.html' % area_dir))
+            area_list = coverage_map['testArea'].get(area_dir, [])
+            area_list.append([time_dir, coverage_value])
+            coverage_map['testArea'][area_dir] = area_list
+
+            time_list = coverage_map['runDate'].get(time_dir, [])
+            time_list.append([area_dir, coverage_value])
+            coverage_map['runDate'][time_dir] = time_list
+            coverage_values[time_dir][area_dir] = coverage_value
+
+    with open('pageData.js', 'w') as pageData:
+        pageData.write("var testData = {};".format(coverage_map))
+
+
+def append(json_path, results_path, kernel_value):
+    latestresults = dict()
+    data = json.load(open(json_path))
+    time_value = os.path.basename(os.path.normpath(results_path))
+    area_dirs = os.listdir(results_path)
+    for area_dir in area_dirs:
+        coverage_value = get_coverage_value(os.path.join(results_path, area_dir, '%s.html' % area_dir))
+        area_list = data['testArea'].get(area_dir, [])
+        test_val = (time_value, coverage_value)
+        area_list.insert(0, test_val)
+        data['testArea'][area_dir] = area_list
+        
+        time_list = data['runDate'].get(time_value, [])
+        time_list.insert(0, [area_dir, coverage_value])
+        data['runDate'][time_value] = time_list
+        data['runDate'] = collections.OrderedDict(sorted(data['runDate'].items(), reverse=True))
+        latestresults[area_dir] = (coverage_value, time_value)
+        data['latestCoverage'] = latestresults
+    
+    data['kernelVersions'][time_value] = kernel_value
+    print("var testData = " + json.dumps(data, indent=4, separators=(',', ': ')) + ";")
+    exit(0)
+
+if len(sys.argv) == 4:
+    append(sys.argv[1], sys.argv[2], sys.argv[3])
+else:
+    main(sys.argv[1])

--- a/Utilities/Launch-GcovTest.ps1
+++ b/Utilities/Launch-GcovTest.ps1
@@ -1,0 +1,130 @@
+param (
+    [Parameter(Mandatory=$true)] [String] $SrcPackagePath,
+    [Parameter(Mandatory=$true)] [String] $ReportDestination,
+    [String] $LogPath,
+    [String] $TestCategory,
+    [String] $TestArea,
+    [Switch] $OverallReport,
+
+    # LISAv2 Params
+    [Parameter(Mandatory=$true)] [String] $RGIdentifier,
+    [Parameter(Mandatory=$true)] [String] $TestPlatform,
+    [Parameter(Mandatory=$true)] [String] $TestLocation,
+    [Parameter(Mandatory=$true)] [String] $StorageAccount,
+    [Parameter(Mandatory=$true)] [String] $XMLSecretFile
+)
+
+$ARM_IMAGE_NAME = "Canonical UbuntuServer 18.04-LTS latest"
+$TAR_PATH = "$($env:ProgramFiles)\Git\usr\bin\tar.exe"
+$CURRENT_DIR = Split-Path -Parent $MyInvocation.MyCommand.Path
+$WORK_DIR = $CURRENT_DIR.Directory.FullName
+
+function Main {
+    $SrcPackagePath = Resolve-Path $SrcPackagePath
+    if ((-not $SrcPackagePath) -or (-not (Test-Path $SrcPackagePath))) {
+        throw "Cannot find kernel source package"
+    }
+
+    $reportName = "report"
+    if ($TestArea) {
+        $reportName = $TestArea.ToLower()
+    } else {
+        $reportName = $TestCategory.ToLower()
+    }
+
+    $tests = @{}
+    if ($TestArea) {
+        $tests += @{"TestArea" = $TestArea}
+    }
+    if ($TestCategory) {
+        $tests += @{"TestCategory" = $TestCategory}
+    }
+
+    Push-Location $WORK_DIR
+
+    if (-not $OverallReport) {
+        Copy-Item -Path $SrcPackagePath "linux-source.deb"
+
+        .\Run-LisaV2.ps1 -RGIdentifier $RGIdentifier -TestPlatform  $TestPlatform `
+            -TestNames 'BUILD-GCOV-KERNEL' -TestLocation $TestLocation `
+            -ARMImageName $ARM_IMAGE_NAME `
+            -TestIterations 1 -StorageAccount $StorageAccount `
+            -XMLSecretFile $XMLSecretFile
+
+        $packagesPath = ".\CodeCoverage\artifacts\packages.tar"
+        if (-not (Test-Path $packagesPath)) {
+            throw "Cannot find kernel artifacts"
+        } else {
+            $packagesPath = Resolve-Path $packagesPath
+            $packagesPath = Get-ChildItem $packagesPath
+        }
+
+        Push-Location $packagesPath.Directory.FullName
+        & $TAR_PATH xf $packagesPath.Name
+        Pop-Location
+
+        .\Run-LisaV2.ps1 -RGIdentifier $RGIdentifier -TestPlatform  $TestPlatform `
+            @tests -TestLocation $TestLocation `
+            -ARMImageName $ARM_IMAGE_NAME `
+            -TestIterations 1 -StorageAccount $StorageAccount `
+            -XMLSecretFile $XMLSecretFile `
+            -EnableCodeCoverage -CustomKernel "localfile:.\CodeCoverage\artifacts\*.deb"
+
+        if ($LogPath) {
+            if (-not (Test-Path $LogPath)) {
+                New-Item -Path $LogPath -Type Directory
+            }
+            if (-not (Test-Path "${LogPath}\logs")) {
+                New-Item -Path "${LogPath}\logs" -Type Directory
+            }
+           
+            Copy-Item -Recurse -Path ".\CodeCoverage\logs\*" -Destination "${LogPath}\logs\" -Force
+            Copy-Item -Recurse -Path ".\CodeCoverage\artifacts" -Destination "${LogPath}\" -Force
+        }
+    } else {
+        $reportName = "overall"
+        if (-not (Test-Path $LogPath)) {
+            throw "Cannot find logs dir"
+        }
+
+        $artifactsPath = Join-Path $LogPath "artifacts"
+        $logsPath = Join-Path $LogPath "logs"
+
+        if ((-not (Test-Path $artifactsPath)) -or (-not (Test-Path $logsPath))) {
+            throw "Cannot find logs"
+        }
+        if (Test-Path ".\CodeCoverage") {
+            Remove-Item -Recurse -Path ".\CodeCoverage"
+        }
+        New-Item -Path ".\CodeCoverage" -Type Directory
+
+        Copy-Item -Recurse -Path $artifactsPath -Destination ".\CodeCoverage"
+        Copy-Item -Recurse -Path $logsPath -Destination ".\CodeCoverage"
+    }
+
+    .\Run-LisaV2.ps1 -RGIdentifier $RGIdentifier -TestPlatform  $TestPlatform `
+        -TestNames "BUILD-GCOV-REPORT" -TestLocation $TestLocation `
+        -ARMImageName $ARM_IMAGE_NAME `
+        -TestIterations 1 -StorageAccount $StorageAccount `
+        -XMLSecretFile $XMLSecretFile `
+        -CustomParameters "GCOV_REPORT_CATEGORY=${reportName}"
+
+    $reportsPath = ".\CodeCoverage\${reportName}.zip"
+    if (-not (Test-Path $reportsPath)) {
+        throw "Cannot find GCOV html report archive"
+    }
+
+    if (-not (Test-Path $ReportDestination)) {
+        New-Item -Path $ReportDestination -Type Directory
+    }
+    $ReportDestination = Join-Path $ReportDestination $reportName
+    if (Test-Path $ReportDestination) {
+        Remove-Item -Path $ReportDestination -Recurse -Force
+    }
+    New-Item -Path $ReportDestination -Type Directory
+
+    Expand-Archive -Path $reportsPath -DestinationPath $ReportDestination
+    Pop-Location
+}
+
+Main

--- a/Utilities/Launch-GcovTest.ps1
+++ b/Utilities/Launch-GcovTest.ps1
@@ -4,6 +4,7 @@ param (
     [String] $LogPath,
     [String] $TestCategory,
     [String] $TestArea,
+    [String] $TestNames,
     [Switch] $OverallReport,
 
     # LISAv2 Params
@@ -38,6 +39,9 @@ function Main {
     }
     if ($TestCategory) {
         $tests += @{"TestCategory" = $TestCategory}
+    }
+    if ($TestNames) {
+        $tests = @{"TestNames" = $TestNames}
     }
 
     Push-Location $WORK_DIR
@@ -77,7 +81,7 @@ function Main {
             if (-not (Test-Path "${LogPath}\logs")) {
                 New-Item -Path "${LogPath}\logs" -Type Directory
             }
-           
+
             Copy-Item -Recurse -Path ".\CodeCoverage\logs\*" -Destination "${LogPath}\logs\" -Force
             Copy-Item -Recurse -Path ".\CodeCoverage\artifacts" -Destination "${LogPath}\" -Force
         }

--- a/XML/Other/ReplaceableTestParameters.xml
+++ b/XML/Other/ReplaceableTestParameters.xml
@@ -195,4 +195,40 @@ Scenario 2 : You need to run all the performance tests quickly.
         <ReplaceThis>LIS_OLD_URL</ReplaceThis>
         <ReplaceWith>http://download.microsoft.com/download/6/8/F/68FE11B8-FAA4-4F8D-8C7D-74DA7F2CFC8C/lis-rpms-4.2.7.tar.gz</ReplaceWith>
     </Parameter>
+    <Parameter>
+        <ReplaceThis>GCOV_BUILD_DIR</ReplaceThis>
+        <ReplaceWith>/build/linux</ReplaceWith>
+    </Parameter>
+    <Parameter>
+        <ReplaceThis>GCOV_BUILD_SOURCE_DEST</ReplaceThis>
+        <ReplaceWith>sources.tar.gz</ReplaceWith>
+    </Parameter>
+    <Parameter>
+        <ReplaceThis>GCOV_BUILD_PACK_DEST</ReplaceThis>
+        <ReplaceWith>packages.tar</ReplaceWith>
+    </Parameter>
+    <Parameter>
+        <ReplaceThis>GCOV_BUILD_SRC_PATH</ReplaceThis>
+        <ReplaceWith>.\linux-source.deb</ReplaceWith>
+    </Parameter>
+    <Parameter>
+        <ReplaceThis>GCOV_BUILD_SRC_NAME</ReplaceThis>
+        <ReplaceWith>linux-source.deb</ReplaceWith>
+    </Parameter>
+    <Parameter>
+        <ReplaceThis>GCOV_BUILD_CONFIG_URL</ReplaceThis>
+        <ReplaceWith>https://raw.githubusercontent.com/LIS/lis-pipeline/master/scripts/package_building/deps-lis/kernel_config/Microsoft/config-azure</ReplaceWith>
+    </Parameter>
+    <Parameter>
+        <ReplaceThis>GCOV_REPORT_LOGS</ReplaceThis>
+        <ReplaceWith>.\CodeCoverage\logs</ReplaceWith>
+    </Parameter>
+    <Parameter>
+        <ReplaceThis>GCOV_REPORT_CATEGORY</ReplaceThis>
+        <ReplaceWith>CORE</ReplaceWith>
+    </Parameter>
+    <Parameter>
+        <ReplaceThis>GCOV_REPORT_SRC_PATH</ReplaceThis>
+        <ReplaceWith>.\CodeCoverage\artifacts\sources.tar.gz</ReplaceWith>
+    </Parameter>
 </ReplaceableTestParameters>

--- a/XML/TestCases/Other.xml
+++ b/XML/TestCases/Other.xml
@@ -13,4 +13,42 @@
         <Area></Area>
         <Tags>disk</Tags>
     </test>
+    <test>
+        <testName>BUILD-GCOV-KERNEL</testName>
+        <TestScript>Build-GcovKernel.ps1</TestScript>
+        <setupType>OneVM</setupType>
+        <OverrideVMSize>Standard_DS14_v2</OverrideVMSize>
+        <files>.\TestScripts\Linux\build_gcov_kernel.sh,.\TestScripts\Linux\utils.sh</files>
+        <Platform>Azure</Platform>
+        <TestParameters>
+            <param>BUILD_DIR="GCOV_BUILD_DIR"</param>
+            <param>SOURCE_DEST="GCOV_BUILD_SOURCE_DEST"</param>
+            <param>PACKAGE_DEST="GCOV_BUILD_PACK_DEST"</param>
+            <param>SRC_PACKAGE_PATH=GCOV_BUILD_SRC_PATH</param>
+            <param>SRC_PACKAGE_NAME="GCOV_BUILD_SRC_NAME"</param>
+            <param>CONFIG_URL="GCOV_BUILD_CONFIG_URL"</param>
+            <param>SkipVerifyKernelLogs=true</param>
+        </TestParameters>
+        <Category></Category>
+        <Area></Area>
+        <Tags>gcov</Tags>
+    </test>
+    <test>
+        <testName>BUILD-GCOV-REPORT</testName>
+        <TestScript>Get-GcovReport.ps1</TestScript>
+        <setupType>OneVM</setupType>
+        <OverrideVMSize>Standard_DS14_v2</OverrideVMSize>
+        <files>.\TestScripts\Linux\generate_gcov.sh,.\TestScripts\Linux\generate_gcov_report.sh,.\TestScripts\Linux\utils.sh</files>
+        <Platform>Azure</Platform>
+        <TestParameters>
+            <param>BUILD_DIR="GCOV_BUILD_DIR"</param>
+            <param>LOCAL_LOGS_PATH=GCOV_REPORT_LOGS</param>
+            <param>TEST_CATEGORY=GCOV_REPORT_CATEGORY</param>
+            <param>LOCAL_SRC_PATH=GCOV_REPORT_SRC_PATH</param>
+            <param>SkipVerifyKernelLogs=true</param>
+        </TestParameters>
+        <Category></Category>
+        <Area></Area>
+        <Tags>gcov</Tags>
+    </test>
 </TestCases>


### PR DESCRIPTION
Changelog:
- Added new test (BUILD-GCOV-KERNEL) to build the kernel from source package with gcov support using custom config.
The test will create a folder "CodeCoverage\artifatcs" in LISA root directory where built packages will be stored.
- Added EnableCodeCoverage option in Run-LISAv2.ps1 that will enable gcov logs collect during the final kernel logs collect (per each test).
This needs to be used along with CustomKernel param (to have the kernel with gcov support installed).
Logs will be stored in "CodeCoverage\logs\${TestName}"
- Added new test (BUILD-GCOV-REPORT) to convert the logs into gcov files, then into html reports.
For now it only generates reports for the following files: hv_kvp.c, hv_fcopy.c, vmbus_drv.c

Supported base distro: Ubuntu