### PR TITLE
Azure: wait 10s between resource group creation retry

### DIFF
--- a/Libraries/Azure.psm1
+++ b/Libraries/Azure.psm1
@@ -515,6 +515,8 @@ Function Create-ResourceGroup([string]$RGName, $location, $CurrentTestData) {
             }
             else {
                 Write-LogErr "Failed to create Resource Group: $RGName."
+                Write-LogInfo "[$FailCounter / 5] Retrying after 10 seconds..."
+                Start-Sleep -Seconds 10
                 $retValue = $false
             }
         }


### PR DESCRIPTION
Sometimes, Azure throttles the requests. In this case, LISAv2 tries to
create resource group without any wait period. Which results in
successive failures, resulting in test Abort.

Adding wait period helps to bypass this issue.