### PR TITLE
TIMESYNC-VDSO: update real-time threshold values

### DIFF
--- a/Testscripts/Windows/Timesync-VDSO.ps1
+++ b/Testscripts/Windows/Timesync-VDSO.ps1
@@ -60,11 +60,11 @@ function Main {
 
     Write-LogInfo "real time: $real :: sys time: $sys"
     # Support VDSO, sys time should be shorter than 1.0 second
-    if (([float]$real -gt 5.0) -or ([float]$sys -gt 1.0)) {
-        Write-LogErr "Error: Check real time is $real(>5.0s), sys time is $sys(>1.0s)"
+    if (([float]$real -gt 10.0) -or ([float]$sys -gt 1.0)) {
+        Write-LogErr "Error: Check real time is $real(>10.0s), sys time is $sys(>1.0s)"
         return "FAIL"
     } else {
-        Write-LogInfo "Check real time is $real(<5.0s), sys time is $sys(<1.0s)"
+        Write-LogInfo "Check real time is $real(<10.0s), sys time is $sys(<1.0s)"
         return "PASS"
     }
 }


### PR DESCRIPTION
Updated real time threshold from 5.0 to 10.0, since on Windows 2019 host, real time is about 7s, sometimes go to 9s.
Changes based on customer feedback in https://github.com/LIS/lis-test/pull/1152

Tests : 
```
[LISAv2 Test Results Summary]
Test Run On           : 02/06/2019 09:02:22
VHD Under Test        : Centos_7.5_x64.vhdx
Total Test Cases      : 1 (1 Pass, 0 Fail, 0 Abort)
Total Time (dd:hh:mm) : 0:0:3

   ID TestCaseName                                                                TestResult TestDuration(in minutes) 
---------------------------------------------------------------------------------------------------------------------
    1 TIMESYNC-VDSO                                                                     PASS                  1.7 

[LISAv2 Test Results Summary]
Test Run On           : 02/06/2019 09:02:45
VHD Under Test        : ubuntu_18.04.1.vhdx
Total Test Cases      : 1 (1 Pass, 0 Fail, 0 Abort)
Total Time (dd:hh:mm) : 0:0:3

   ID TestCaseName                                                                TestResult TestDuration(in minutes) 
---------------------------------------------------------------------------------------------------------------------
    1 TIMESYNC-VDSO                                                                     PASS                 1.25 
```