### PR TITLE
Add new DYNAMIC-MEMORY-TOP-LOAD-AVERAGE testcase

### DIFF
--- a/Testscripts/Linux/DM_Top_Load_Average.sh
+++ b/Testscripts/Linux/DM_Top_Load_Average.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache License.
+############################################################################
+# Description:
+#   This script verifies that with the Dynamic Memory enabled,
+#   load average is lower than 1.
+#   This is a regression test based on upstream commit:
+#   "Drivers: hv: Ballon: Make pressure posting thread sleep interruptibly"
+############################################################################
+
+# Source utils.sh
+. utils.sh || {
+    echo "Error: unable to source utils.sh!"
+    echo "TestAborted" > state.txt
+    exit 0
+}
+# Source constants file and initialize most common variables
+UtilsInit
+# sleep 8 minutes then check result
+LogMsg "Sleeping 8 minutes before checking load average..."
+sleep 480
+# Check load aveage value of top command
+IFS=" " read -r -a load_average <<< "$(top|head -n 1 | awk -F 'load average:' '{print $2}' | awk -F ',' '{print $1,$2,$3}')"
+threshold="1"
+for value in "${load_average[@]}"; do
+    # use awk to compare the value and 1
+    LogMsg "value=$value threshold=$threshold"
+    st=$(echo "$value $threshold" | awk '{if ($1 < $2) print 0; else print 1}')
+    if [ $st -eq "1" ]; then
+        LogErr "The load average value of top is too high: $value"
+        SetTestStateFailed
+        exit 0
+    fi
+done
+LogMsg "Test successful. Top load average value is lower than 1"
+SetTestStateCompleted
+exit 0

--- a/XML/TestCases/FunctionalTests-DynamicMemory.xml
+++ b/XML/TestCases/FunctionalTests-DynamicMemory.xml
@@ -358,4 +358,25 @@
         <Tags>memory</Tags>
         <Priority>2</Priority>
     </test>
+    <test>
+        <testName>DYNAMIC-MEMORY-TOP-LOAD-AVERAGE</testName>
+        <setupScript>.\Testscripts\Windows\DM-CONFIGURE-MEMORY.ps1</setupScript>
+        <testScript>DM_Top_Load_Average.sh</testScript>
+        <files>.\Testscripts\Linux\DM_Top_Load_Average.sh,.\Testscripts\Linux\utils.sh</files>
+        <setupType>OneVM</setupType>
+        <TestParameters>
+            <param>enableDM=yes</param>
+            <param>minMem=1024MB</param>
+            <param>maxMem=2GB</param>
+            <param>startupMem=1024MB</param>
+            <param>memWeight=0</param>
+            <param>staticMem=1024MB</param>
+        </TestParameters>
+        <timeout>1200</timeout>
+        <Platform>HyperV</Platform>
+        <Category>Functional</Category>
+        <Area>Dynamic_Memory</Area>
+        <Tags>memory</Tags>
+        <Priority>2</Priority>
+    </test>
 </TestCases>


### PR DESCRIPTION
This is a regression test based on upstream commit:
"Drivers: hv: Ballon: Make pressure posting thread sleep interruptibly"

Test steps:
1. Enable dynamic memory with Hyper-V manager.
2. Start the guest, check the top metrics after waiting for several minutes.
3. Check load average value of past minutes.

Tests : 
```

[LISAv2 Test Results Summary]
Test Run On           : 02/06/2019 17:21:08
VHD Under Test        : ubuntu_18.04.1.vhdx
Total Test Cases      : 1 (1 Pass, 0 Fail, 0 Abort)
Total Time (dd:hh:mm) : 0:0:10

   ID TestCaseName                                                                TestResult TestDuration(in minutes) 
---------------------------------------------------------------------------------------------------------------------
    1 DYNAMIC-MEMORY-TOP-LOAD-AVERAGE                                                   PASS                 9.24 


[LISAv2 Test Results Summary]
Test Run On           : 02/06/2019 17:21:05
VHD Under Test        : rhel_7.6.vhdx
Total Test Cases      : 1 (1 Pass, 0 Fail, 0 Abort)
Total Time (dd:hh:mm) : 0:0:10

   ID TestCaseName                                                                TestResult TestDuration(in minutes) 
---------------------------------------------------------------------------------------------------------------------
    1 DYNAMIC-MEMORY-TOP-LOAD-AVERAGE                                                   PASS                 9.14 
```
