### PR TITLE
Framework: Upstream stable kernel support

### DIFF
--- a/Testscripts/Linux/customKernelInstall.sh
+++ b/Testscripts/Linux/customKernelInstall.sh
@@ -9,18 +9,22 @@
 
 #######################################################################
 #
-#
-#
 # Description:
+#  This script is used to deploy Linux kernel.
+#  Various installation sources are supported - web, git, packages.
+#
 #######################################################################
 
-UTIL_FILE="./utils.sh"
-. ${UTIL_FILE} || {
-    errMsg="Error: missing ${UTIL_FILE} file"
-    echo "${errMsg}"
-    SetTestStateAborted
-    exit 10
+supported_kernels=(ppa proposed proposed-azure proposed-edge latest
+                    linuxnext netnext upstream-stable)
+
+# Source utils.sh
+. utils.sh || {
+    echo "ERROR: unable to source utils.sh!"
+    echo "TestAborted" > state.txt
+    exit 0
 }
+UtilsInit
 
 while echo $1 | grep ^- > /dev/null; do
     eval $( echo $1 | sed 's/-//g' | tr -d '\012')=$2
@@ -28,10 +32,12 @@ while echo $1 | grep ^- > /dev/null; do
     shift
 done
 
-if [ -z "$CustomKernel" ]; then
-    echo "Please mention -CustomKernel next"
+if [[ -z "$CustomKernel" ]] || [[ ! " ${supported_kernels[*]} " =~ $CustomKernel ]]; then
+    echo "Please mention a supported kernel type with -CustomKernel, accepted values are:
+        ${supported_kernels[@]}"
     exit 1
 fi
+
 if [ -z "$logFolder" ]; then
     logFolder="~"
     echo "-logFolder is not mentioned. Using ~"
@@ -47,16 +53,13 @@ LOG_FILE="$logFolder/build-CustomKernel.txt"
 
 touch $LOG_FILE
 
-LogMsg()
-{
+function LogMsg() {
     echo $(date "+%b %d %Y %T") : "${1}"    # Add the time stamp to the log message
     echo "${1}" >> $LOG_FILE
 }
 
-CheckInstallLockUbuntu()
-{
-    pidof dpkg
-    if [ $? -eq 0 ];then
+function CheckInstallLockUbuntu() {
+    if pidof dpkg;then
         LogMsg "Another install is in progress. Waiting 10 seconds."
         sleep 10
         CheckInstallLockUbuntu
@@ -67,12 +70,12 @@ CheckInstallLockUbuntu()
 
 function Install_Build_Deps {
     #
-    # Installing packages required for the build process.
+    # Installing packages required for the build process
     #
     GetDistro
     update_repos
     case "$DISTRO" in
-    redhat_7|centos_7)
+    redhat_7|centos_7|redhat_8|centos_8)
         install_epel
         LogMsg "Installing package Development Tools"
         yum -y groupinstall "Development Tools"  >> $LOG_FILE 2>&1
@@ -82,6 +85,15 @@ function Install_Build_Deps {
 
         # Use ccache to speed up recompilation
         PATH="/usr/lib64/ccache:"$PATH
+
+        # git from default CentOS/RedHat 7.x does not support git tag format syntax
+        # temporarily use a community repo, then remove it
+        if [[ ${CustomKernel} == "upstream-stable" ]]; then
+            yum remove -y git
+            rpm -U https://centos7.iuscommunity.org/ius-release.rpm
+            yum install -y git2u
+            rpm -e ius-release
+        fi
         ;;
 
     ubuntu*|debian*)
@@ -99,7 +111,7 @@ function Install_Build_Deps {
     esac
 }
 
-function Get_Upstream_Source (){
+function Get_Upstream_Source() {
     #
     # Downloading kernel sources from git
     #
@@ -117,23 +129,35 @@ function Get_Upstream_Source (){
     pushd "$source" > /dev/null
     git reset --hard HEAD~1 > /dev/null
     git fetch > /dev/null
-    git checkout -f master > /dev/null
+
+    # for upstream stable we want to get the latest release,
+    # not the master branch which defaults to linux-next daily
+    if [[ ${CustomKernel} == "upstream-stable" ]]; then
+        # get the most recent release tree, example "v4.19"
+        tree_version=$(git tag | sort --version-sort --reverse | grep -E "^v[0-9]{1,3}\.[0-9]{1,3}$" -m1)
+        # get the latest version from the tree, example "refs/tags/v4.19.11"
+        release=$(git tag -l --format='%(refname)' | grep -E "$tree_version" | sort --version-sort | tail -1)
+        git checkout -f "$release" > /dev/null
+    else
+        git checkout -f master > /dev/null
+    fi
 
     if [[ $? -ne 0 ]];then
         exit 1
     fi
+
     git pull > /dev/null
     popd > /dev/null
     popd > /dev/null
     echo "$source"
 }
 
-function Build_Kernel (){
+function Build_Kernel() {
     #
     # Building the kernel
     #
     source="$1"
-    thread_number=$(grep -c ^processor /proc/cpuinfo)
+    thread_number=$(nproc)
 
     pushd "$source"
     LogMsg "Start to make old config"
@@ -141,30 +165,33 @@ function Build_Kernel (){
     check_exit_status "Make kernel config" "exit"
 
     LogMsg "Start to build kernel"
-    make -j$thread_number >> $LOG_FILE 2>&1
+    make -j"$thread_number" >> $LOG_FILE 2>&1
     check_exit_status "Build kernel" "exit"
 
     LogMsg "Start to install modules"
-    make modules_install -j$thread_number >> $LOG_FILE 2>&1
+    make modules_install -j"$thread_number" >> $LOG_FILE 2>&1
     check_exit_status "Install modules" "exit"
 
     LogMsg "Start to install kernel"
-    make install -j$thread_number >> $LOG_FILE 2>&1
+    make install -j"$thread_number" >> $LOG_FILE 2>&1
     check_exit_status "Install kernel" "exit"
 
-    if [[ $DISTRO -eq redhat_7 ]] || [[ $DISTRO -eq centos_7 ]]; then
+    if [[ $DISTRO -eq redhat_7 ]] || [[ $DISTRO -eq centos_7 ]] || \
+    [[ $DISTRO -eq redhat_8 ]] || [[ $DISTRO -eq centos_8 ]]; then
         LogMsg "Set GRUB_DEFAULT=0 in /etc/default/grub"
         sed -i 's/GRUB_DEFAULT=saved/GRUB_DEFAULT=0/g' /etc/default/grub
         grub2-mkconfig -o /boot/grub2/grub.cfg >> $LOG_FILE 2>&1
     fi
-
     popd
 }
 
-InstallKernel()
-{
+function InstallKernel() {
     if [ "${CustomKernel}" == "linuxnext" ]; then
+        # daily upstream linux-next
         kernelSource="https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git"
+    elif [ "${CustomKernel}" == "upstream-stable" ]; then
+        # kernel.org stable tree
+        kernelSource="git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git"
     elif [ "${CustomKernel}" == "proposed" ]; then
         export DEBIAN_FRONTEND=noninteractive
         release=$(lsb_release -c -s)
@@ -175,9 +202,9 @@ InstallKernel()
         apt clean all
         apt -y update >> $LOG_FILE 2>&1
         apt -y --fix-missing upgrade >> $LOG_FILE 2>&1
-        apt install -y -qq linux-tools-generic/$release-proposed
-        apt install -y -qq linux-cloud-tools-generic/$release-proposed
-        apt install -y -qq linux-cloud-tools-common/$release-proposed
+        apt install -y -qq linux-tools-generic/"$release"-proposed
+        apt install -y -qq linux-cloud-tools-generic/"$release"-proposed
+        apt install -y -qq linux-cloud-tools-common/"$release"-proposed
         kernelInstallStatus=$?
         if [ $kernelInstallStatus -ne 0 ]; then
             LogMsg "CUSTOM_KERNEL_FAIL"
@@ -195,7 +222,7 @@ InstallKernel()
         LogMsg "Installing linux-azure kernel from $release proposed repository."
         apt clean all
         apt -y update >> $LOG_FILE 2>&1
-        apt install -yq linux-azure/$release >> $LOG_FILE 2>&1
+        apt install -yq linux-azure/"$release" >> $LOG_FILE 2>&1
         kernelInstallStatus=$?
         if [ $kernelInstallStatus -ne 0 ]; then
             LogMsg "CUSTOM_KERNEL_FAIL"
@@ -213,7 +240,7 @@ InstallKernel()
         LogMsg "Installing linux-azure-edge kernel from $release proposed repository."
         apt clean all
         apt -y update >> $LOG_FILE 2>&1
-        apt install -yq linux-azure-edge/$release >> $LOG_FILE 2>&1
+        apt install -yq linux-azure-edge/"$release" >> $LOG_FILE 2>&1
         kernelInstallStatus=$?
         if [ $kernelInstallStatus -ne 0 ]; then
             LogMsg "CUSTOM_KERNEL_FAIL"
@@ -226,7 +253,7 @@ InstallKernel()
         DISTRO=$(grep -ihs "buntu\|Suse\|Fedora\|Debian\|CentOS\|Red Hat Enterprise Linux" /etc/{issue,*release,*version})
         if [[ $DISTRO =~ "Ubuntu" ]];
         then
-            LogMsg "Enabling ppa repositry..."
+            LogMsg "Enabling ppa repository..."
             DEBIAN_FRONTEND=noninteractive add-apt-repository --yes ppa:canonical-kernel-team/ppa
             apt -y update >> $LOG_FILE 2>&1
             LogMsg "Installing linux-image-generic from proposed repository."
@@ -266,20 +293,20 @@ InstallKernel()
         kernelSource="https://git.kernel.org/pub/scm/linux/kernel/git/davem/net-next.git"
     elif [[ $CustomKernel == *.deb ]]; then
         LogMsg "Custom Kernel:$CustomKernel"
-        apt-get update
+        apt -y update
 
         LogMsg "Adding packages required by the kernel."
-        apt-get install -y binutils
+        apt install -y binutils
 
         LogMsg "Removing packages that do not allow the kernel to be installed"
-        apt-get remove -y grub-legacy-ec2
+        apt remove -y grub-legacy-ec2
 
         if [[ $CustomKernel =~ "http" ]];then
             CheckInstallLockUbuntu
             LogMsg "Debian package web link detected. Downloading $CustomKernel"
-            apt-get install -y wget
-            apt-get remove -y linux-cloud-tools-common
-            wget $CustomKernel
+            apt install -y wget
+            apt remove -y linux-cloud-tools-common
+            wget "$CustomKernel"
             LogMsg "Installing ${CustomKernel##*/}"
             dpkg -i "${CustomKernel##*/}"  >> $LOG_FILE 2>&1
             image_file=$(ls -1 *.deb* | grep -v "dbg" | sed -n 1p)
@@ -314,7 +341,7 @@ InstallKernel()
             SetTestStateFailed
         else
             LogMsg "CUSTOM_KERNEL_SUCCESS"
-            DEBIAN_FRONTEND=noninteractive apt-get -y remove linux-image-$(uname -r)
+            DEBIAN_FRONTEND=noninteractive apt -y remove linux-image-$(uname -r)
             SetTestStateCompleted
         fi
     elif [[ $CustomKernel == *.rpm ]]; then
@@ -323,7 +350,7 @@ InstallKernel()
         if [[ $CustomKernel =~ "http" ]];then
             yum -y install wget
             LogMsg "RPM package web link detected. Downloading $CustomKernel"
-            wget $CustomKernel
+            wget "$CustomKernel"
             LogMsg "Installing ${CustomKernel##*/}"
             rpm -ivh "${CustomKernel##*/}"  >> $LOG_FILE 2>&1
             kernelInstallStatus=$?
@@ -354,7 +381,8 @@ InstallKernel()
             grub2-set-default 0
         fi
     fi
-    if [[ ${CustomKernel} == "linuxnext" ]] || [[ ${CustomKernel} == "netnext" ]]; then
+    if [[ ${CustomKernel} == "linuxnext" ]] || [[ ${CustomKernel} == "netnext" ]] || \
+        [[ ${CustomKernel} == "upstream-stable" ]]; then
         LogMsg "Custom Kernel:$CustomKernel"
         Install_Build_Deps
         sourceDir=$(Get_Upstream_Source "." "$kernelSource")
@@ -370,5 +398,6 @@ InstallKernel()
     SetTestStateCompleted
     return $kernelInstallStatus
 }
+
 InstallKernel
 exit 0


### PR DESCRIPTION
Introduced upstream-stable as a new custom kernel supported. This will pull the latest stable from kernel.org.
Simplified logic in checking valid kernel types.

---

**linux-next daily:**
[INFO ] Old kernel: 4.15.0-1037-azure
[INFO ] New kernel: 5.0.0-rc5-next-20190207

**upstream stable latest:**
ubuntu:
[INFO ] Old kernel: 4.15.0-1037-azure
[INFO ] New kernel: 4.20.7

redhat:
[INFO ] Old kernel: 3.10.0-862.11.6.el7.x86_64
[INFO ] New kernel: 4.20.7

**Expected failure:**
[ERROR] Only ppa proposed proposed-azure proposed-edge latest linuxnext netnext upstream-stable are supported. E.g. -CustomKernel linuxnext/netnext/proposed. 
			Or use -CustomKernel <link to deb file>, -CustomKernel <link to rpm file>
[ERROR] Custom Kernel: liunxnext installation FAIL. Aborting tests.
[ERROR] Failed to set custom config in VMs, abort the test