### PR TITLE
Rename CustomParameters into CustomTestParameters, enable CustomParameters for the parameters.

### DIFF
--- a/JenkinsPipelines/Run-Boot-Stress-Tests.groovy
+++ b/JenkinsPipelines/Run-Boot-Stress-Tests.groovy
@@ -62,7 +62,7 @@ def ExecuteTest( JenkinsUser, UpstreamBuildNumber, ImageSource, CustomVHD, Custo
                                 " -TestLocation '${TestRegion}'" +
                                 " -OverrideVMSize '${VMSize}'" +
                                 " -TestIterations ${TestIterations}" +
-                                " -EnableAcceleratedNetworking"
+                                " -CustomParameters 'Networking=SRIOV'"
                                 )
                                 archiveArtifacts '*-TestLogs.zip'
                                 junit "Report\\*-junit.xml"

--- a/LISAv2-Framework.psm1
+++ b/LISAv2-Framework.psm1
@@ -50,19 +50,18 @@ function Start-LISAv2 {
 
 		# [Optional] Parameters for changing framework behavior.
 		[int]    $TestIterations = 1,
-		[string] $TiPSessionId,
-		[string] $TiPCluster,
 		[string] $XMLSecretFile = "",
 		[switch] $EnableTelemetry,
 		[switch] $UseExistingRG,
 
-		# [Optional] Parameters for Overriding VM Configuration.
+		# [Optional] Parameters for setting TiPCluster=ClusterId;TipSessionId=SessionId;DiskType=Managed/Unmanaged;Networking=SRIOV/Synthetic.
 		[string] $CustomParameters = "",
+
+		# [Optional] Parameters for Overriding VM Configuration.
+		[string] $CustomTestParameters = "",
 		[string] $OverrideVMSize = "",
-		[switch] $EnableAcceleratedNetworking,
 		[ValidateSet('Default','Keep','Delete',IgnoreCase = $true)]
 		[string] $ResourceCleanup,
-		[switch] $UseManagedDisks,
 		[switch] $DeployVMPerEachTest,
 		[string] $VMGeneration = "",
 
@@ -169,7 +168,7 @@ function Start-LISAv2 {
 			# Validate all the XML files and then import test cases from them for test
 			Validate-XmlFiles -ParentFolder $workingDirectory
 
-			$testController.LoadTestCases($workingDirectory, $CustomParameters)
+			$testController.LoadTestCases($workingDirectory, $CustomTestParameters)
 
 			# Create report folder
 			$reportFolder = Join-Path $workingDirectory "Report"

--- a/Libraries/Azure.psm1
+++ b/Libraries/Azure.psm1
@@ -704,7 +704,7 @@ Function Generate-AzureDeployJSONFile ($RGName, $ImageName, $osVHD, $RGXMLData, 
     $RGrandomWord = ([System.IO.Path]::GetRandomFileName() -replace '[^a-z]')
     $RGRandomNumber = Get-Random -Minimum 11111 -Maximum 99999
 
-    $UseManagedDisks = $CurrentTestData.AdditionalHWConfig.DiskType -imatch "Managed"
+    $UseManagedDisks = $CurrentTestData.AdditionalHWConfig.DiskType -contains "managed"
     if ($UseManagedDisks) {
         $DiskType = "Managed"
     } else {

--- a/Libraries/CommonFunctions.psm1
+++ b/Libraries/CommonFunctions.psm1
@@ -167,7 +167,7 @@ Function Collect-TestCases($TestXMLs, $TestCategory, $TestArea, $TestNames, $Tes
 }
 
 # This function set the AdditionalHWConfig of the test case data
-# Called when -EnableAcceleratedNetworking or -UseManagedDisks is set
+# Called when DiskType=Managed/Unmanaged or Networking=SRIOV/Synthetic set in -CustomParameters
 function Set-AdditionalHWConfigInTestCaseData ($CurrentTestData, $ConfigName, $ConfigValue) {
 	Write-LogInfo "The AdditionalHWConfig $ConfigName of case $($CurrentTestData.testName) is set to $ConfigValue"
 	if (!$CurrentTestData.AdditionalHWConfig) {

--- a/Run-LisaV2.ps1
+++ b/Run-LisaV2.ps1
@@ -63,16 +63,16 @@ Param(
 
 	# [Optional] Parameters for changing framework behavior.
 	[int]    $TestIterations = 1,
-	[string] $TiPSessionId,
-	[string] $TiPCluster,
 	[string] $XMLSecretFile = "",
 	[switch] $EnableTelemetry,
 	[switch] $UseExistingRG,
 
-	# [Optional] Parameters for Overriding VM Configuration.
+	# [Optional] Parameters for setting TiPCluster, TipSessionId, DiskType=Managed/Unmanaged, Networking=SRIOV/Synthetic.
 	[string] $CustomParameters = "",
+
+	# [Optional] Parameters for Overriding VM Configuration.
+	[string] $CustomTestParameters = "",
 	[string] $OverrideVMSize = "",
-	[switch] $EnableAcceleratedNetworking,
 	[ValidateSet('Default','Keep','Delete',IgnoreCase = $true)]
 
 	#ResourceCleanup options:
@@ -80,7 +80,6 @@ Param(
 	#	"Keep" = Preserve resources for analysis irrespective of test result.
 	#	"Delete" = Delete resources irrespective of test result.
 	[string] $ResourceCleanup,
-	[switch] $UseManagedDisks,
 	[switch] $DeployVMPerEachTest,
 	[string] $VMGeneration = "",
 

--- a/TestControllers/AzureController.psm1
+++ b/TestControllers/AzureController.psm1
@@ -40,11 +40,11 @@ Class AzureController : TestController
 	[void] ParseAndValidateParameters([Hashtable]$ParamTable) {
 		$this.ARMImageName = $ParamTable["ARMImageName"]
 		$this.StorageAccount = $ParamTable["StorageAccount"]
-		$this.TestProvider.TipSessionId = $ParamTable["TipSessionId"]
-		$this.TestProvider.TipCluster = $ParamTable["TipCluster"]
 
 		$parameterErrors = ([TestController]$this).ParseAndValidateParameters($ParamTable)
 
+		$this.TestProvider.TipSessionId = $this.CustomParams["TipSessionId"]
+		$this.TestProvider.TipCluster = $this.CustomParams["TipCluster"]
 		if ( !$this.ARMImageName -and !$this.OsVHD ) {
 			$parameterErrors += "-ARMImageName '<Publisher> <Offer> <Sku> <Version>', or -OsVHD <'VHD_Name.vhd'> is required."
 		}

--- a/Utilities/Launch-GcovTest.ps1
+++ b/Utilities/Launch-GcovTest.ps1
@@ -111,7 +111,7 @@ function Main {
         -ARMImageName $ARM_IMAGE_NAME `
         -TestIterations 1 -StorageAccount $StorageAccount `
         -XMLSecretFile $XMLSecretFile `
-        -CustomParameters "GCOV_REPORT_CATEGORY=${reportName}"
+        -CustomTestParameters "GCOV_REPORT_CATEGORY=${reportName}"
 
     $reportsPath = ".\CodeCoverage\${reportName}.zip"
     if (-not (Test-Path $reportsPath)) {

--- a/XML/Other/ReplaceableTestParameters.xml
+++ b/XML/Other/ReplaceableTestParameters.xml
@@ -6,27 +6,27 @@ We can convert any hardcoded test parameter in LISAv2 test definition to a "Repl
 Syntax :
 
 There are two ways to start the tests -
-1.  Provide '-CustomParameters' to commandline.
+1.  Provide '-CustomTestParameters' to commandline.
     Run-LisaV2.ps1 -Platform <Platform> `
              -Area <Area> `
              .
              .
              .
-             -CustomParameters "ReplaceThis1=ReplaceWith1;ReplaceThis2=ReplaceWith2"
+             -CustomTestParameters "ReplaceThis1=ReplaceWith1;ReplaceThis2=ReplaceWith2"
 
-2.  Provide 'CustomParameters' in .\XML\TestParameters.xml
+2.  Provide 'CustomTestParameters' in .\XML\TestParameters.xml
     a. Edit TestParameters.xml file as follows:
-    <CustomParameters>ReplaceThis1=ReplaceWith1;ReplaceThis2=ReplaceWith2</CustomParameters>
+    <CustomTestParameters>ReplaceThis1=ReplaceWith1;ReplaceThis2=ReplaceWith2</CustomTestParameters>
     Run-LisaV2.ps1 -TestParameters .\XML\TestParameters.xml
 
 Note: Multiple replace operations can be done using sign - semicolumn (";").
 
 Scenario 1 : You need to run the DPDK test with "git://dpdk.org/next/dpdk-next-net", instead of default.
-    -CustomParameters "DPDK_SOURCE_URL=git://dpdk.org/next/dpdk-next-net"
+    -CustomTestParameters "DPDK_SOURCE_URL=git://dpdk.org/next/dpdk-next-net"
 
 Scenario 2 : You need to run all the performance tests quickly. 
     The default test duration is 300 seconds for each scenario.
--CustomParameters "NTTTCP_RUNTIME_IN_SECONDS=120;IPERF3_RUNTIME_IN_SECONDS=120;FIO_RUNTIME_IN_SECONDS=120;DPDK_TEST_DURATION_IN_SECONDS=60"
+-CustomTestParameters "NTTTCP_RUNTIME_IN_SECONDS=120;IPERF3_RUNTIME_IN_SECONDS=120;FIO_RUNTIME_IN_SECONDS=120;DPDK_TEST_DURATION_IN_SECONDS=60"
 
 -->
 

--- a/XML/TestParameters.xml
+++ b/XML/TestParameters.xml
@@ -59,21 +59,25 @@
 	<CustomKernel></CustomKernel>
 	<CustomLIS></CustomLIS>
 
+	<!-- [Optional] Enable kernel code coverage. -->
+	<EnableCodeCoverage></EnableCodeCoverage>
+
 	<!-- [Optional] Parameters for changing framework behavior. -->
 	<TestIterations></TestIterations>
-	<TiPSessionId></TiPSessionId>
-	<TiPCluster></TiPCluster>
 	<XMLSecretFile></XMLSecretFile>
 	<EnableTelemetry></EnableTelemetry>
+	<UseExistingRG></UseExistingRG>
+
+	<!-- [Optional] Parameters for setting TiPCluster, TipSessionId, DiskType=Managed/Unmanaged, Networking=SRIOV/Synthetic.
+	format is -CustomParameters "TiPCluster=ClusterId;TipSessionId=SessionId;DiskType=Managed;Networking=SRIOV"
+	-->
+	<CustomParameters></CustomParameters>
 
 	<!-- [Optional] Parameters for Overriding VM Configuration. -->
-	<CustomParameters></CustomParameters>
+	<CustomTestParameters></CustomTestParameters>
 	<OverrideVMSize></OverrideVMSize>
-	<EnableAcceleratedNetworking></EnableAcceleratedNetworking>
 	<OverrideHyperVDiskMode></OverrideHyperVDiskMode>
-	<ForceDeleteResources></ForceDeleteResources>
-	<UseManagedDisks></UseManagedDisks>
-	<DoNotDeleteVMs></DoNotDeleteVMs>
+	<ResourceCleanup></ResourceCleanup>
 	<VMGeneration></VMGeneration>
 
 	<!-- [Optional] Database details. -->


### PR DESCRIPTION
Rename the current CustomParameters to CustomTestParameters, which is for overwriting the default parameter values defined in ReplaceableTestParameters.xml 

And enable CustomParameters for the parameters, the value format is the same as “Key1=Value1;Key2=Value2;…”, which can include TiPCluster=<ClusterId>;TipSession=<SessionId>; DiskType=Managed;Networking=SRIOV


![image](https://user-images.githubusercontent.com/10083705/52692659-7625b900-2f9f-11e9-8f06-79d6c4732b48.png)
