### PR TITLE
Fix the value of the test case results

### DIFF
--- a/Testscripts/Windows/BVT-NET-IFUP-IFDOWN.ps1
+++ b/Testscripts/Windows/BVT-NET-IFUP-IFDOWN.ps1
@@ -21,9 +21,8 @@ function Main {
     #
     # Run the guest VM side script to verify  BVT-NET-IFUP-IFDOWN
     #
-    $stateFile = "${LogDir}\state.txt"
     $bvtCmd = "echo '${VMPassword}' | sudo -S -s eval `"export HOME=``pwd``;bash ${remoteScript} > BVT-NET-IFUP-IFDOWN.log`""
-    Run-LinuxCmd -username $VMUserName -password $VMPassword -ip $Ipv4 -port $VMPort $bvtCmd -RunInBackground -runAsSudo
+    Run-LinuxCmd -username $VMUserName -password $VMPassword -ip $Ipv4 -port $VMPort $bvtCmd -RunInBackground -runAsSudo | Out-Null
     # Wait for the test to finish running on VM
     do {
         if ($TestPlatform -eq "HyperV") {
@@ -34,20 +33,20 @@ function Main {
         else {
             $newIp = $allVmData.PublicIP
         }
-        Copy-RemoteFiles -download -downloadFrom $newIp -files "/home/${VMUserName}/state.txt" `
-            -downloadTo $LogDir -port $VMPort -username $VMUserName -password $VMPassword
-        $contents = Get-Content -Path $stateFile
+        $state = Run-LinuxCmd -ip $newIp -port $VMPort -username $VMUserName -password $VMPassword "cat state.txt" -ignoreLinuxExitCode:$true
+        Write-LogInfo "Current status:$state"
         Start-Sleep -Seconds 30
-    } until (($contents -eq "TestCompleted") -or ($contents -eq "TestAborted") `
-     -or ($contents -eq "TestFailed") -or ((Get-Date) -gt $expiration))
+    } until (($state -eq "TestCompleted") -or ($state -eq "TestAborted") `
+     -or ($state -eq "TestFailed") -or ((Get-Date) -gt $expiration))
     Copy-RemoteFiles -download -downloadFrom $newIp -files "/home/${VMUserName}/BVT-NET-IFUP-IFDOWN.log" `
         -downloadTo $LogDir -port $VMPort -username $VMUserName -password $VMPassword
-    if (($contents -eq "TestAborted") -or ($contents -eq "TestFailed") -or ((Get-Date) -gt $expiration)) {
-        Write-LogErr "Error: Running $remoteScript script failed on VM!"
+    if (($state -eq "TestAborted") -or ($state -eq "TestFailed") -or ((Get-Date) -gt $expiration)) {
+        Write-LogErr "Running $remoteScript script failed on VM!"
         return "FAIL"
     }
     else {
         Write-LogInfo "Test BVT-NET-IFUP-IFDOWN PASSED !"
+        return "PASS"
     }
 }
 Main -VMName $AllVMData.RoleName -HvServer $TestLocation `

--- a/Testscripts/Windows/BVT-VERIFY-SSHD-CONFIG.ps1
+++ b/Testscripts/Windows/BVT-VERIFY-SSHD-CONFIG.ps1
@@ -12,11 +12,11 @@ function Main {
         $testScript = "BVT-VERIFY-SSHD-CONFIG.py"
 
         Copy-RemoteFiles -uploadTo $AllVMData.PublicIP -port $AllVMData.SSHPort -files $currentTestData.files -username $user -password $password -upload
-        Run-LinuxCmd -username $user -password $password -ip $AllVMData.PublicIP -port $AllVMData.SSHPort -command "chmod +x *" -runAsSudo
+        Run-LinuxCmd -username $user -password $password -ip $AllVMData.PublicIP -port $AllVMData.SSHPort -command "chmod +x *" -runAsSudo | Out-Null
 
         Write-LogInfo "Executing : ${testScript}"
         $output=Run-LinuxCmd -username $user -password $password -ip $AllVMData.PublicIP -port $AllVMData.SSHPort -command "python ${testScript}" -runAsSudo
-        Run-LinuxCmd -username $user -password $password -ip $AllVMData.PublicIP -port $AllVMData.SSHPort -command "mv Runtime.log ${testScript}.log" -runAsSudo
+        Run-LinuxCmd -username $user -password $password -ip $AllVMData.PublicIP -port $AllVMData.SSHPort -command "mv Runtime.log ${testScript}.log" -runAsSudo | Out-Null
         Copy-RemoteFiles -download -downloadFrom $AllVMData.PublicIP -files "/home/$user/state.txt, /home/$user/Summary.log, /home/$user/${testScript}.log" -downloadTo $LogDir -port $AllVMData.SSHPort -username $user -password $password
         $testResult = Get-Content $LogDir\Summary.log
         $testStatus = Get-Content $LogDir\state.txt

--- a/Testscripts/Windows/BVT-VERIFY-VHD-PREREQUISITES.ps1
+++ b/Testscripts/Windows/BVT-VERIFY-VHD-PREREQUISITES.ps1
@@ -43,11 +43,11 @@ function Main {
         }
 
         Copy-RemoteFiles -uploadTo $AllVMData.PublicIP -port $AllVMData.SSHPort -files $currentTestData.files -username $user -password $password -upload
-        Run-LinuxCmd -username $user -password $password -ip $AllVMData.PublicIP -port $AllVMData.SSHPort -command "chmod +x *.py" -runAsSudo
+        Run-LinuxCmd -username $user -password $password -ip $AllVMData.PublicIP -port $AllVMData.SSHPort -command "chmod +x *.py" -runAsSudo | Out-Null
 
         Write-LogInfo "Executing : ${testScript}"
         $consoleOut = Run-LinuxCmd -username $user -password $password -ip $AllVMData.PublicIP -port $AllVMData.SSHPort -command "python ${testScript} -d $detectedDistro" -runAsSudo
-        Run-LinuxCmd -username $user -password $password -ip $AllVMData.PublicIP -port $AllVMData.SSHPort -command "mv Runtime.log ${testScript}.log" -runAsSudo
+        Run-LinuxCmd -username $user -password $password -ip $AllVMData.PublicIP -port $AllVMData.SSHPort -command "mv Runtime.log ${testScript}.log" -runAsSudo | Out-Null
         Copy-RemoteFiles -download -downloadFrom $AllVMData.PublicIP -files "/home/$user/${testScript}.log" -downloadTo $LogDir -port $AllVMData.SSHPort -username $user -password $password
         $errorCount = 0
         foreach ($testString in $matchstrings) {


### PR DESCRIPTION
Fixes #711 

Because of the refactor related to how test cases return the status results, the following tests need to be fixed in order to return proper statuses:
BVT-VERIFY-VHD-PREREQUISITES Test case script result does not match known ones:>>> PASS<<<
BVT-VERIFY-SSHD-CONFIG Test case script result does not match known ones:>>> PASS<<<
BVT-NET-IFUP-IFDOWN Test case script result does not match known ones:>>>2015<<<