### PR TITLE
Azure: .\XML\RegionAndStorageAccounts.xml will be updated using secret file.

### DIFF
--- a/TestControllers/TestController.psm1
+++ b/TestControllers/TestController.psm1
@@ -132,6 +132,17 @@ Class TestController
 		}
 	}
 
+	[void] UpdateRegionAndStorageAccountsFromSecretsFile()
+	{
+		if ($this.XMLSecrets.secrets.RegionAndStorageAccounts) {
+			$FilePath = Resolve-Path ".\XML\RegionAndStorageAccounts.xml"
+			$CurrentStorageXML = [xml](Get-Content $FilePath)
+			$CurrentStorageXML.AllRegions.InnerXml = $this.XMLSecrets.secrets.RegionAndStorageAccounts.InnerXml
+			$CurrentStorageXML.Save($FilePath)
+			Write-LogInfo "Updated $FilePath from secrets file."
+		}
+	}
+
 	[void] PrepareTestEnvironment($XMLSecretFile) {
 		if ($XMLSecretFile) {
 			if (Test-Path -Path $XMLSecretFile) {
@@ -141,6 +152,7 @@ Class TestController
 				Get-LISAv2Tools -XMLSecretFile $XMLSecretFile
 
 				$this.UpdateXMLStringsFromSecretsFile()
+				$this.UpdateRegionAndStorageAccountsFromSecretsFile()
 			} else {
 				Write-LogErr "The Secret file provided: $XMLSecretFile does not exist"
 			}


### PR DESCRIPTION
If, 
```
$XMLSecrets = [xml] (Get-Content .\XML\AzureSecrets.xml)
$CurrentStorageXML = [xml](Get-Content .\XML\RegionAndStorageAccounts.xml)
```
then,
`$XMLSecrets.secrets.RegionAndStorageAccounts` should have all the child elements same as `$CurrentStorageXML.AllRegions`

.\XML\RegionAndStorageAccounts.xml will only be update if, XMLsecrets has `$XMLSecrets.secrets.RegionAndStorageAccounts` parent element.
Otherwise, RegionAndStorageAccounts.xml will be used, as is.
