### PR TITLE
Fix: Replaceable test parameters can also replace test case names

### DIFF
--- a/TestControllers/TestController.psm1
+++ b/TestControllers/TestController.psm1
@@ -234,9 +234,18 @@ Class TestController
 		foreach ( $test in $allTests) {
 			# Inject replaceable parameters
 			foreach ($ReplaceableParameter in $ReplaceableTestParameters.ReplaceableTestParameters.Parameter) {
-				if ($test.InnerXml -imatch $ReplaceableParameter.ReplaceThis) {
-					$test.InnerXml = $test.InnerXml.Replace($ReplaceableParameter.ReplaceThis,$ReplaceableParameter.ReplaceWith)
-					Write-LogInfo "$($ReplaceableParameter.ReplaceThis)=$($ReplaceableParameter.ReplaceWith) injected to case $($test.testName)"
+				$FindReplaceArray = @(
+					("=$($ReplaceableParameter.ReplaceThis)<" ,"=$($ReplaceableParameter.ReplaceWith)<" ),
+					("=`"$($ReplaceableParameter.ReplaceThis)`"" ,"=`"$($ReplaceableParameter.ReplaceWith)`""),
+					(">$($ReplaceableParameter.ReplaceThis)<" ,">$($ReplaceableParameter.ReplaceWith)<")
+				)
+				foreach ($item in $FindReplaceArray) {
+					$Find = $item[0]
+					$Replace = $item[1]
+					if ($test.InnerXml -imatch $Find) {
+						$test.InnerXml = $test.InnerXml.Replace($Find,$Replace)
+						Write-LogInfo "$($ReplaceableParameter.ReplaceThis)=$($ReplaceableParameter.ReplaceWith) injected to case $($test.testName)"
+					}
 				}
 			}
 
@@ -538,6 +547,3 @@ Class TestController
 		$this.TestSummary.SaveHtmlTestSummary(".\Report\TestSummary-$global:TestID.html")
 	}
 }
-
-
-

--- a/XML/Other/ReplaceableTestParameters.xml
+++ b/XML/Other/ReplaceableTestParameters.xml
@@ -19,7 +19,13 @@ There are two ways to start the tests -
     <CustomParameters>ReplaceThis1=ReplaceWith1;ReplaceThis2=ReplaceWith2</CustomParameters>
     Run-LisaV2.ps1 -TestParameters .\XML\TestParameters.xml
 
-Note: Multiple replace operations can be done using sign - semicolumn (";").
+Note:   1. Multiple replace operations can be done using sign - semicolumn (";").
+        2. LISAv2 supports replacing parameters,
+            ...if parameter is assigned in one of the following format
+            ...in Test Definition -
+            a.  <ParameterName>REPLACEABLE_PARAMETER1</ParameterName>
+            b.  <param>ParameterName=REPLACEABLE_PARAMETER2</param>
+            c.  <param>ParameterName="REPLACEABLE_PARAMETER3"</param>
 
 Scenario 1 : You need to run the DPDK test with "git://dpdk.org/next/dpdk-next-net", instead of default.
     -CustomParameters "DPDK_SOURCE_URL=git://dpdk.org/next/dpdk-next-net"


### PR DESCRIPTION
Fixes #723 