### PR TITLE
Cleanup testcase xmls

### DIFF
--- a/XML/TestCases/FunctionalTests-DynamicMemory.xml
+++ b/XML/TestCases/FunctionalTests-DynamicMemory.xml
@@ -218,7 +218,7 @@
         <Priority>0</Priority>
     </test>
     <test>
-        <testName>HOT-REMOVE</testName>
+        <testName>DYNAMIC-MEMORY-HOT-REMOVE</testName>
         <testScript>DM_HotAddRemove.ps1</testScript>
         <files>.\Testscripts\Linux\utils.sh</files>
         <setupType>TwoVM</setupType>
@@ -243,7 +243,7 @@
         <Priority>1</Priority>
     </test>
     <test>
-        <testName>STARTUP-LOW-COMPETE</testName>
+        <testName>DYNAMIC-MEMORY-STARTUP-LOW-COMPETE</testName>
         <testScript>DM_StartupLowCompete.ps1</testScript>
         <setupType>TwoVM</setupType>
         <TestParameters>
@@ -265,7 +265,7 @@
         <Priority>0</Priority>
     </test>
     <test>
-        <testName>CLEAN-SHUTDOWN</testName>
+        <testName>DYNAMIC-MEMORY-CLEAN-SHUTDOWN</testName>
         <testScript>DM_CleanShutdown.ps1</testScript>
         <setupType>TwoVM</setupType>
         <TestParameters>
@@ -304,7 +304,7 @@
         </TestParameters>
         <Platform>HyperV</Platform>
         <Category>Functional</Category>
-        <Area>Dynamic_Memory</Area>
+        <Area>DYNAMIC_MEMORY</Area>
         <Tags>memory</Tags>
         <Priority>2</Priority>
     </test>
@@ -330,7 +330,7 @@
         <timeout>2600</timeout>
         <Platform>HyperV</Platform>
         <Category>Functional</Category>
-        <Area>Dynamic_Memory</Area>
+        <Area>DYNAMIC_MEMORY</Area>
         <Tags>memory</Tags>
         <Priority>2</Priority>
     </test>
@@ -354,7 +354,7 @@
         <timeout>1200</timeout>
         <Platform>HyperV</Platform>
         <Category>Functional</Category>
-        <Area>Dynamic_Memory</Area>
+        <Area>DYNAMIC_MEMORY</Area>
         <Tags>memory</Tags>
         <Priority>2</Priority>
     </test>
@@ -375,7 +375,7 @@
         <timeout>1200</timeout>
         <Platform>HyperV</Platform>
         <Category>Functional</Category>
-        <Area>Dynamic_Memory</Area>
+        <Area>DYNAMIC_MEMORY</Area>
         <Tags>memory</Tags>
         <Priority>2</Priority>
     </test>
@@ -397,7 +397,7 @@
         </TestParameters>
         <Platform>HyperV</Platform>
         <Category>Functional</Category>
-        <Area>Dynamic_Memory</Area>
+        <Area>DYNAMIC_MEMORY</Area>
         <Tags>memory</Tags>
         <Priority>1</Priority>
     </test>
@@ -419,7 +419,7 @@
         </TestParameters>
         <Platform>HyperV</Platform>
         <Category>Functional</Category>
-        <Area>Dynamic_Memory</Area>
+        <Area>DYNAMIC_MEMORY</Area>
         <Tags>memory</Tags>
         <Priority>1</Priority>
     </test>
@@ -438,7 +438,7 @@
         </TestParameters>
         <Platform>HyperV</Platform>
         <Category>Functional</Category>
-        <Area>Dynamic_Memory</Area>
+        <Area>DYNAMIC_MEMORY</Area>
         <Tags>memory</Tags>
         <Priority>1</Priority>
     </test>

--- a/XML/TestCases/FunctionalTests-LiveMigration.xml
+++ b/XML/TestCases/FunctionalTests-LiveMigration.xml
@@ -1,6 +1,6 @@
 <TestCases>
     <test>
-        <testName>LIVEMIGRATE</testName>
+        <testName>LIVE-MIGRATE</testName>
         <testScript>NET-LIVEMIG.ps1</testScript>
         <timeout>600</timeout>
         <setupType>OneVMCluster</setupType>
@@ -14,7 +14,7 @@
         <Priority>0</Priority>
     </test>
     <test>
-        <testName>LIVEMIGRATE-FAILOVER</testName>
+        <testName>LIVE-MIGRATE-FAILOVER</testName>
         <testScript>NET-LIVEMIG.ps1</testScript>
         <Timeout>1800</Timeout>
         <setupType>OneVMCluster</setupType>
@@ -29,7 +29,7 @@
         <Priority>1</Priority>
     </test>
     <test>
-        <testName>LIVEMIGRATE-MEM4GB-CORE8</testName>
+        <testName>LIVE-MIGRATE-MEM4GB-CORE8</testName>
         <setupScript>.\TestScripts\Windows\SETUP-Change-CPU.ps1,.\TestScripts\Windows\Set-VM-Memory.ps1</setupScript>
         <testScript>NET-LIVEMIG.ps1</testScript>
         <Timeout>600</Timeout>
@@ -51,7 +51,7 @@
         <Priority>2</Priority>
     </test>
     <test>
-        <testName>LIVEMIG_MEM8GB_CORE16</testName>
+        <testName>LIVE-MIGRATE-MEM8GB-CORE16</testName>
         <setupScript>.\TestScripts\Windows\SETUP-Change-CPU.ps1,.\TestScripts\Windows\Set-VM-Memory.ps1</setupScript>
         <testScript>NET-LIVEMIG.ps1</testScript>
         <Timeout>600</Timeout>
@@ -73,7 +73,7 @@
         <Priority>2</Priority>
     </test>
     <test>
-        <testName>LIVEMIG_MEM16GB_CORE32</testName>
+        <testName>LIVE-MIGRATE-MEM16GB-CORE32</testName>
         <setupScript>.\TestScripts\Windows\SETUP-Change-CPU.ps1,.\TestScripts\Windows\Set-VM-Memory.ps1</setupScript>
         <testScript>NET-LIVEMIG.ps1</testScript>
         <Timeout>600</Timeout>
@@ -95,7 +95,7 @@
         <Priority>2</Priority>
     </test>
     <test>
-        <testName>QUICKMIGRATE</testName>
+        <testName>LIVE-MIGRATE-QUICK-MIGRATE</testName>
         <testScript>NET-LIVEMIG.ps1</testScript>
         <timeout>600</timeout>
         <setupType>OneVMCluster</setupType>
@@ -109,7 +109,7 @@
         <Priority>0</Priority>
     </test>
     <test>
-        <testName>COPYFILE-DURING-MIGRATION</testName>
+        <testName>LIVE-MIGRATE-COPYFILE-DURING-MIGRATION</testName>
         <testScript>NET-LIVEMIG.ps1</testScript>
         <Timeout>600</Timeout>
         <setupType>OneVMCluster</setupType>
@@ -124,7 +124,7 @@
         <Priority>2</Priority>
     </test>
     <test>
-        <testName>QUICKMIG_MEM4GB_CORE8</testName>
+        <testName>LIVE-MIGRATE-QUICKMIG-MEM4GB-CORE8</testName>
         <setupScript>.\TestScripts\Windows\SETUP-Change-CPU.ps1,.\TestScripts\Windows\Set-VM-Memory.ps1</setupScript>
         <testScript>NET-LIVEMIG.ps1</testScript>
         <Timeout>600</Timeout>
@@ -145,7 +145,7 @@
         <Priority>2</Priority>
     </test>
     <test>
-        <testName>QUICKMIG_MEM8GB_CORE16</testName>
+        <testName>LIVE-MIGRATE-QUICKMIG-MEM8GB-CORE16</testName>
         <setupScript>.\TestScripts\Windows\SETUP-Change-CPU.ps1,.\TestScripts\Windows\Set-VM-Memory.ps1</setupScript>
         <testScript>NET-LIVEMIG.ps1</testScript>
         <Timeout>600</Timeout>
@@ -166,7 +166,7 @@
         <Priority>2</Priority>
     </test>
     <test>
-        <testName>QUICKMIG_MEM16GB_CORE32</testName>
+        <testName>LIVE-MIGRATE-QUICKMIG-MEM16GB-CORE32</testName>
         <setupScript>.\TestScripts\Windows\SETUP-Change-CPU.ps1,.\TestScripts\Windows\Set-VM-Memory.ps1</setupScript>
         <testScript>NET-LIVEMIG.ps1</testScript>
         <Timeout>600</Timeout>

--- a/XML/TestCases/FunctionalTests-NVME.xml
+++ b/XML/TestCases/FunctionalTests-NVME.xml
@@ -164,6 +164,6 @@
         <Category>Functional</Category>
         <Area>NVME</Area>
         <Tags>nvme,filesystem</Tags>
-       <Priority>0</Priority>
+        <Priority>0</Priority>
     </test>
 </TestCases>

--- a/XML/TestCases/FunctionalTests-OL.xml
+++ b/XML/TestCases/FunctionalTests-OL.xml
@@ -10,12 +10,12 @@
         </TestParameters>
         <Platform>OL</Platform>
         <Category>OL</Category>
-        <Area>ol</Area>
+        <Area>OL</Area>
         <Tags>package</Tags>
         <Priority>0</Priority>
     </test>
     <test>
-        <TestName>KERNEL-CONFIG-VERIFY-TEST</TestName>
+        <TestName>OL-KERNEL-CONFIG-VERIFY-TEST</TestName>
         <testScript>KERNEL-CONFIG-VERIFY-TEST.ps1</testScript>
         <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\kernel_config_verify_test.sh</files>
         <setupType>OneVM</setupType>

--- a/XML/TestCases/NestedVmTests.xml
+++ b/XML/TestCases/NestedVmTests.xml
@@ -15,7 +15,7 @@
         <Timeout>720</Timeout>
         <Platform>Azure</Platform>
         <Category>Functional</Category>
-        <Area>Nested</Area>
+        <Area>NESTED</Area>
         <Tags>nested,nested-kvm</Tags>
         <Priority>1</Priority>
     </test>
@@ -39,7 +39,7 @@
         </TestParameters>
         <Platform>Azure</Platform>
         <Category>Performance</Category>
-        <Area>Nested</Area>
+        <Area>NESTED</Area>
         <Tags>nested,nested-kvm</Tags>
         <Priority>2</Priority>
     </test>
@@ -69,7 +69,7 @@
         </TestParameters>
         <Platform>HyperV</Platform>
         <Category>Performance</Category>
-        <Area>Nested</Area>
+        <Area>NESTED</Area>
         <Tags>nested,nested-kvm</Tags>
         <Priority>2</Priority>
     </test>
@@ -101,7 +101,7 @@
         </TestParameters>
         <Platform>Azure</Platform>
         <Category>Performance</Category>
-        <Area>Nested</Area>
+        <Area>NESTED</Area>
         <Tags>nested,nested-kvm</Tags>
         <Priority>2</Priority>
     </test>
@@ -131,7 +131,7 @@
         </TestParameters>
         <Platform>HyperV</Platform>
         <Category>Performance</Category>
-        <Area>Nested</Area>
+        <Area>NESTED</Area>
         <Tags>nested,nested-kvm</Tags>
         <Priority>2</Priority>
     </test>
@@ -164,7 +164,7 @@
         </TestParameters>
         <Platform>Azure</Platform>
         <Category>Performance</Category>
-        <Area>Nested</Area>
+        <Area>NESTED</Area>
         <Tags>nested,nested-kvm</Tags>
         <Priority>2</Priority>
     </test>
@@ -191,7 +191,7 @@
         </TestParameters>
         <Platform>HyperV</Platform>
         <Category>Performance</Category>
-        <Area>Nested</Area>
+        <Area>NESTED</Area>
         <Tags>nested,nested-kvm</Tags>
         <Priority>2</Priority>
     </test>
@@ -217,7 +217,7 @@
         </TestParameters>
         <Platform>HyperV</Platform>
         <Category>Performance</Category>
-        <Area>Nested</Area>
+        <Area>NESTED</Area>
         <Tags>nested,nested-hyperv</Tags>
         <Priority>2</Priority>
     </test>
@@ -244,7 +244,7 @@
         </TestParameters>
         <Platform>HyperV</Platform>
         <Category>Performance</Category>
-        <Area>Nested</Area>
+        <Area>NESTED</Area>
         <Tags>nested,nested-kvm</Tags>
         <Priority>2</Priority>
     </test>
@@ -269,7 +269,7 @@
         </TestParameters>
         <Platform>HyperV</Platform>
         <Category>Performance</Category>
-        <Area>Nested</Area>
+        <Area>NESTED</Area>
         <Tags>nested,nested-kvm</Tags>
         <Priority>2</Priority>
     </test>
@@ -296,7 +296,7 @@
         </TestParameters>
         <Platform>Azure</Platform>
         <Category>Performance</Category>
-        <Area>Nested</Area>
+        <Area>NESTED</Area>
         <Tags>nested,nested-kvm</Tags>
         <Priority>2</Priority>
     </test>
@@ -327,7 +327,7 @@
         </TestParameters>
         <Platform>HyperV</Platform>
         <Category>Performance</Category>
-        <Area>Storage</Area>
+        <Area>STORAGE</Area>
         <Tags>nested,nested-hyperv</Tags>
         <Priority>2</Priority>
     </test>
@@ -359,7 +359,7 @@
         </TestParameters>
         <Platform>HyperV</Platform>
         <Category>Performance</Category>
-        <Area>Storage</Area>
+        <Area>STORAGE</Area>
         <Tags>nested,nested-hyperv</Tags>
         <Priority>2</Priority>
     </test>
@@ -392,7 +392,7 @@
         </TestParameters>
         <Platform>Azure</Platform>
         <Category>Performance</Category>
-        <Area>Storage</Area>
+        <Area>STORAGE</Area>
         <Tags>nested,nested-hyperv</Tags>
         <Priority>2</Priority>
     </test>
@@ -427,7 +427,7 @@
         </TestParameters>
         <Platform>Azure</Platform>
         <Category>Performance</Category>
-        <Area>Storage</Area>
+        <Area>STORAGE</Area>
         <Tags>nested,nested-hyperv</Tags>
         <Priority>2</Priority>
     </test>
@@ -454,7 +454,7 @@
         </TestParameters>
         <Platform>HyperV</Platform>
         <Category>Performance</Category>
-        <Area>Nested</Area>
+        <Area>NESTED</Area>
         <Tags>nested,nested-kvm</Tags>
         <Priority>2</Priority>
     </test>
@@ -478,7 +478,7 @@
         </TestParameters>
         <Platform>Azure</Platform>
         <Category>Performance</Category>
-        <Area>Nested</Area>
+        <Area>NESTED</Area>
         <Tags>nested,nested-kvm</Tags>
         <Priority>2</Priority>
     </test>
@@ -503,7 +503,7 @@
         </TestParameters>
         <Platform>HyperV</Platform>
         <Category>Performance</Category>
-        <Area>Nested</Area>
+        <Area>NESTED</Area>
         <Tags>nested,nested-hyperv</Tags>
         <Priority>2</Priority>
     </test>
@@ -527,7 +527,7 @@
         </TestParameters>
         <Platform>Azure</Platform>
         <Category>Performance</Category>
-        <Area>Nested</Area>
+        <Area>NESTED</Area>
         <Tags>nested,nested-hyperv</Tags>
         <Priority>2</Priority>
     </test>

--- a/XML/TestCases/PerformanceTests.xml
+++ b/XML/TestCases/PerformanceTests.xml
@@ -19,7 +19,7 @@
         </TestParameters>
         <Platform>Azure,HyperV</Platform>
         <Category>Performance</Category>
-        <Area>Network</Area>
+        <Area>NETWORK</Area>
         <Tags>network,hv_netvsc</Tags>
         <Priority>1</Priority>
     </test>
@@ -44,7 +44,7 @@
         </TestParameters>
         <Platform>Azure,HyperV</Platform>
         <Category>Performance</Category>
-        <Area>Network</Area>
+        <Area>NETWORK</Area>
         <Tags>network,hv_netvsc,sriov</Tags>
         <Priority>1</Priority>
     </test>
@@ -69,7 +69,7 @@
         </TestParameters>
         <Platform>Azure,HyperV</Platform>
         <Category>Performance</Category>
-        <Area>Network</Area>
+        <Area>NETWORK</Area>
         <Tags>network,hv_netvsc</Tags>
         <Priority>1</Priority>
     </test>
@@ -94,7 +94,7 @@
         </TestParameters>
         <Platform>Azure,HyperV</Platform>
         <Category>Performance</Category>
-        <Area>Network</Area>
+        <Area>NETWORK</Area>
         <Tags>network,hv_netvsc,sriov</Tags>
         <Priority>1</Priority>
     </test>    
@@ -113,7 +113,7 @@
         </TestParameters>
         <Platform>Azure,HyperV</Platform>
         <Category>Performance</Category>
-        <Area>Network</Area>
+        <Area>NETWORK</Area>
         <Tags>network,hv_netvsc</Tags>
         <Priority>1</Priority>
     </test>
@@ -135,7 +135,7 @@
         </TestParameters>
         <Platform>Azure,HyperV</Platform>
         <Category>Performance</Category>
-        <Area>Network</Area>
+        <Area>NETWORK</Area>
         <Tags>network,hv_netvsc,sriov</Tags>
         <Priority>1</Priority>
     </test>
@@ -159,7 +159,7 @@
         </TestParameters>
         <Platform>Azure,HyperV</Platform>
         <Category>Performance</Category>
-        <Area>Network</Area>
+        <Area>NETWORK</Area>
         <Tags>network,hv_netvsc</Tags>
         <Priority>1</Priority>
     </test>
@@ -186,7 +186,7 @@
         </TestParameters>
         <Platform>Azure,HyperV</Platform>
         <Category>Performance</Category>
-        <Area>Network</Area>
+        <Area>NETWORK</Area>
         <Tags>network,hv_netvsc,sriov</Tags>
         <Priority>1</Priority>
     </test>
@@ -214,7 +214,7 @@
         <cleanupScript>.\Testscripts\Windows\RemoveHardDisk.ps1</cleanupScript>
         <Platform>Azure,HyperV</Platform>
         <Category>Performance</Category>
-        <Area>Storage</Area>
+        <Area>STORAGE</Area>
         <Tags>hv_storvsc,storage</Tags>
         <Priority>1</Priority>
     </test>
@@ -238,7 +238,7 @@
         </TestParameters>
         <Platform>Azure</Platform>
         <Category>Performance</Category>
-        <Area>Storage</Area>
+        <Area>STORAGE</Area>
         <Tags>hv_storvsc,storage</Tags>
         <Priority>1</Priority>
     </test>
@@ -260,7 +260,7 @@
         </TestParameters>
         <Platform>Azure</Platform>
         <Category>Performance</Category>
-        <Area>Storage</Area>
+        <Area>STORAGE</Area>
         <Tags>hv_storvsc,storage</Tags>
         <Priority>2</Priority>
     </test>
@@ -282,7 +282,7 @@
         </TestParameters>
         <Platform>Azure</Platform>
         <Category>Performance</Category>
-        <Area>Storage</Area>
+        <Area>STORAGE</Area>
         <Tags>hv_storvsc,storage</Tags>
         <Priority>2</Priority>
     </test>
@@ -307,7 +307,7 @@
         </TestParameters>
         <Platform>Azure</Platform>
         <Category>Performance</Category>
-        <Area>Storage</Area>
+        <Area>STORAGE</Area>
         <Tags>hv_storvsc,storage</Tags>
         <Priority>2</Priority>
     </test>
@@ -332,7 +332,7 @@
         </TestParameters>
         <Platform>Azure</Platform>
         <Category>Performance</Category>
-        <Area>Storage</Area>
+        <Area>STORAGE</Area>
         <Tags>hv_storvsc,storage</Tags>
         <Priority>2</Priority>
     </test>
@@ -359,7 +359,7 @@
         </TestParameters>
         <Platform>Azure,HyperV</Platform>
         <Category>Performance</Category>
-        <Area>Network</Area>
+        <Area>NETWORK</Area>
         <Tags>hv_netvsc,network</Tags>
         <Priority>1</Priority>
     </test>
@@ -386,7 +386,7 @@
         </TestParameters>
         <Platform>Azure,HyperV</Platform>
         <Category>Performance</Category>
-        <Area>Network</Area>
+        <Area>NETWORK</Area>
         <Tags>hv_netvsc,network,sriov</Tags>
         <Priority>1</Priority>
     </test>
@@ -425,7 +425,7 @@
         </TestParameters>
         <Platform>Azure,HyperV</Platform>
         <Category>Performance</Category>
-        <Area>Network</Area>
+        <Area>NETWORK</Area>
         <Tags>network,hv_netvsc</Tags>
         <Priority>1</Priority>
     </test>
@@ -449,7 +449,7 @@
         </TestParameters>
         <Platform>Azure,HyperV</Platform>
         <Category>Performance</Category>
-        <Area>Network</Area>
+        <Area>NETWORK</Area>
         <Tags>network,hv_netvsc</Tags>
         <Priority>1</Priority>
     </test>
@@ -473,7 +473,7 @@
         </TestParameters>
         <Platform>Azure,HyperV</Platform>
         <Category>Performance</Category>
-        <Area>Network</Area>
+        <Area>NETWORK</Area>
         <Tags>network,hv_netvsc</Tags>
         <Priority>1</Priority>
     </test>
@@ -497,7 +497,7 @@
         </TestParameters>
         <Platform>Azure,HyperV</Platform>
         <Category>Performance</Category>
-        <Area>Network</Area>
+        <Area>NETWORK</Area>
         <Tags>network,hv_netvsc</Tags>
         <Priority>1</Priority>
     </test>
@@ -540,7 +540,7 @@
             <param>GOLANG_INSTALL_PACKAGE=https://partnerpipelineshare.blob.core.windows.net/binarytools/go1.11.4.linux-amd64.tar.gz</param>
         </TestParameters>
         <Category>Performance</Category>
-        <Area>Golang</Area>
+        <Area>GOLANG</Area>
         <Tags>golang</Tags>
         <Priority>2</Priority>
     </test>

--- a/XML/TestCases/StressTests.xml
+++ b/XML/TestCases/StressTests.xml
@@ -9,7 +9,7 @@
         </TestParameters>
         <Platform>Azure</Platform>
         <Category>Stress</Category>
-        <Area>stress</Area>
+        <Area>STRESS</Area>
         <Tags>stress,boot</Tags>
         <Priority>1</Priority>
     </test>
@@ -26,7 +26,7 @@
         </TestParameters>
         <Platform>Azure</Platform>
         <Category>Stress</Category>
-        <Area>stress</Area>
+        <Area>STRESS</Area>
         <Tags>stress,boot,network,sriov</Tags>
         <Priority>0</Priority>
     </test>
@@ -40,7 +40,7 @@
         </TestParameters>
         <Platform>Azure,HyperV</Platform>
         <Category>Stress</Category>
-        <Area>stress</Area>
+        <Area>STRESS</Area>
         <Tags>stress</Tags>
         <Priority>1</Priority>
     </test>
@@ -54,7 +54,7 @@
         </TestParameters>
         <Platform>HyperV</Platform>
         <Category>Stress</Category>
-        <Area>stress</Area>
+        <Area>STRESS</Area>
         <Tags>stress</Tags>
         <Priority>1</Priority>
     </test>
@@ -64,7 +64,7 @@
         <setupType>OneVM</setupType>
         <Platform>HyperV</Platform>
         <Category>Stress</Category>
-        <Area>stress</Area>
+        <Area>STRESS</Area>
         <Tags>stress</Tags>
         <Priority>0</Priority>
     </test>
@@ -80,7 +80,7 @@
         </TestParameters>
         <Platform>HyperV</Platform>
         <Category>Stress</Category>
-        <Area>stress</Area>
+        <Area>STRESS</Area>
         <Tags>stress</Tags>
         <Priority>1</Priority>
     </test>
@@ -93,7 +93,7 @@
         </TestParameters>
         <Platform>HyperV</Platform>
         <Category>Stress</Category>
-        <Area>stress</Area>
+        <Area>STRESS</Area>
         <Tags>stress</Tags>
         <Priority>0</Priority>
     </test>
@@ -120,7 +120,7 @@
         </TestParameters>
         <Platform>HyperV,Azure</Platform>
         <Category>Stress</Category>
-        <Area>stress</Area>
+        <Area>STRESS</Area>
         <Tags>stress,network,sriov</Tags>
     </test>
 </TestCases>


### PR DESCRIPTION
Some Test areas are  in lowercase in xmls , they should be only uppercase in order to be uniform . 
Also some testcase names need the  test area in the name to be easier to identify what the test case covers (some need to be in more uniform state ) 