### PR TITLE
Rename global ResultFailed/ResultPassed to ResultFail/ResultPass

### DIFF
--- a/Documents/How-to-use.md
+++ b/Documents/How-to-use.md
@@ -49,6 +49,7 @@ If you add a custom test menu, you will need to re-build the Jenkins menu, and t
                 $resultPass: PASS
                 $resultFail: FAIL
                 $resultAborted: ABORTED
+                $resultSkipped: SKIPPED
                 $IsWindowsImage: Whether the test image is Windows
 
             ii. For Azure

--- a/Libraries/TestLogs.psm1
+++ b/Libraries/TestLogs.psm1
@@ -104,9 +104,9 @@ function Collect-TestLogs {
 	)
 	# Note: This is a temporary solution until a standard is decided
 	# for what string py/sh scripts return
-	$resultTranslation = @{"TestCompleted" = $global:ResultPassed;
+	$resultTranslation = @{"TestCompleted" = $global:ResultPass;
 							"TestSkipped" = $global:ResultSkipped;
-							"TestFailed" = $global:ResultFailed;
+							"TestFailed" = $global:ResultFail;
 							"TestAborted" = $global:ResultAborted;
 						}
 

--- a/Libraries/TestReport.psm1
+++ b/Libraries/TestReport.psm1
@@ -370,9 +370,9 @@ Class TestSummary
 		$strHtml += "<table>"
 		$strHtml += "<TR><TD class=`"bg3`" colspan=`"2`">Total Executed TestCases - $($this.TotalTc)</TD></TR>"
 		$strHtml += "<TR><TD class=`"bg3`" colspan=`"2`">[&nbsp;" + `
-			"<span> <span style=`"color:#008000;`"><strong>$($this.TotalPassTc)</strong></span></span> - $($global:ResultPassed), " + `
+			"<span> <span style=`"color:#008000;`"><strong>$($this.TotalPassTc)</strong></span></span> - $($global:ResultPass), " + `
 			"<span> <span style=`"color:#cccccc;`"><strong>$($this.TotalSkippedTc)</strong></span></span> - $($global:ResultSkipped), " + `
-			"<span> <span style=`"color:#ff0000;`"><strong>$($this.TotalFailTc)</strong></span></span> - $($global:ResultFailed), " + `
+			"<span> <span style=`"color:#ff0000;`"><strong>$($this.TotalFailTc)</strong></span></span> - $($global:ResultFail), " + `
 			"<span> <span style=`"color:#ff0000;`"><strong><span style=`"background-color:#ffff00;`">$($this.TotalAbortedTc)</span></strong></span></span> - $($global:ResultAborted) " + `
 			"]</TD></TR>"
 		$strHtml += "<TR><TD class=`"bg3`" colspan=`"2`">Total Execution Time(dd:hh:mm) $durationStr</TD></TR>"
@@ -406,17 +406,17 @@ Class TestSummary
 
 		$testSummaryLinePassSkip = "<tr><td>$ExecutionCount</td><td>$TestName</td><td>$Duration min</td><td>" + '{0}' + "</td></tr>"
 		$testSummaryLineFailAbort = "<tr><td>$ExecutionCount</td><td>$TestName$($this.GetReproVMDetails($AllVMData))</td><td>$Duration min</td><td>" + '{0}' + "</td></tr>"
-		if ($TestResult -imatch $global:ResultPassed) {
+		if ($TestResult -imatch $global:ResultPass) {
 			$this.TotalPassTc += 1
-			$testResultRow = "<span style='color:green;font-weight:bolder'>$($global:ResultPassed)</span>"
+			$testResultRow = "<span style='color:green;font-weight:bolder'>$($global:ResultPass)</span>"
 			$this.HtmlSummary += $testSummaryLinePassSkip -f @($testResultRow)
 		} elseif ($TestResult -imatch $global:ResultSkipped) {
 			$this.TotalSkippedTc += 1
 			$testResultRow = "<span style='background-color:gray;font-weight:bolder'>$($global:ResultSkipped)</span>"
 			$this.HtmlSummary += $testSummaryLinePassSkip -f @($testResultRow)
-		} elseif ($TestResult -imatch $global:ResultFailed) {
+		} elseif ($TestResult -imatch $global:ResultFail) {
 			$this.TotalFailTc += 1
-			$testResultRow = "<span style='color:red;font-weight:bolder'>$($global:ResultFailed)</span>"
+			$testResultRow = "<span style='color:red;font-weight:bolder'>$($global:ResultFail)</span>"
 			$this.HtmlSummary += $testSummaryLineFailAbort -f @($testResultRow)
 		} elseif ($TestResult -imatch $global:ResultAborted) {
 			$this.TotalAbortedTc += 1
@@ -429,9 +429,9 @@ Class TestSummary
 			$this.HtmlSummary += $testSummaryLineFailAbort -f @($testResultRow)
 		}
 
-		Write-LogInfo "CURRENT - $($global:ResultPassed)    - $($this.TotalPassTc)"
+		Write-LogInfo "CURRENT - $($global:ResultPass)    - $($this.TotalPassTc)"
 		Write-LogInfo "CURRENT - $($global:ResultSkipped) - $($this.TotalSkippedTc)"
-		Write-LogInfo "CURRENT - $($global:ResultFailed)    - $($this.TotalFailTc)"
+		Write-LogInfo "CURRENT - $($global:ResultFail)    - $($this.TotalFailTc)"
 		Write-LogInfo "CURRENT - $($global:ResultAborted) - $($this.TotalAbortedTc)"
 	}
 

--- a/TestControllers/TestController.psm1
+++ b/TestControllers/TestController.psm1
@@ -188,9 +188,9 @@ Class TestController
 		$skippedResult = "SKIPPED"
 		$failResult = "FAIL"
 		$abortedResult = "ABORTED"
-		Set-Variable -Name ResultPassed  -Value $passResult -Scope Global
+		Set-Variable -Name ResultPass -Value $passResult -Scope Global
 		Set-Variable -Name ResultSkipped -Value $skippedResult -Scope Global
-		Set-Variable -Name ResultFailed  -Value $failResult -Scope Global
+		Set-Variable -Name ResultFail -Value $failResult -Scope Global
 		Set-Variable -Name ResultAborted -Value $abortedResult -Scope Global
 		$this.TestCaseStatus = @($passResult, $skippedResult, $failResult, $abortedResult)
 		$this.TestCasePassStatus = @($passResult, $skippedResult)
@@ -443,7 +443,7 @@ Class TestController
 			$scriptName = ($_.InvocationInfo.ScriptName).Replace($PWD,".")
 			Write-LogErr "EXCEPTION: $errorMessage"
 			Write-LogErr "Source: Line $line in script $scriptName."
-			$currentTestResult.TestResult = $global:ResultFailed
+			$currentTestResult.TestResult = $global:ResultFail
 		}
 
 		# Do log collecting and VM clean up


### PR DESCRIPTION
In many ps1 test scripts, the old names used, to avoid change bunch of files to align new names, we choose to rename global ResultFailed/ResultPassed back to ResultFail/ResultPass.

Part fix for #763 