### PR TITLE
SR-IOV-Utils.sh fix

### DIFF
--- a/Testscripts/Linux/SR-IOV-Utils.sh
+++ b/Testscripts/Linux/SR-IOV-Utils.sh
@@ -77,7 +77,7 @@ VerifyVF()
         vf_interface=$(ls /sys/class/net/ | grep -v 'eth0\|eth1\|lo' | head -1)
     else
         synthetic_interface=$(ip addr | grep "$VF_IP1" | awk '{print $NF}')
-        vf_interface=$(find /sys/devices/* -name "*${synthetic_interface}*" | grep "pci" | sed 's/\// /g' | awk '{print $12}')
+        vf_interface=$(find /sys/devices/* -name "*${synthetic_interface}" | grep "pci" | sed 's/\// /g' | awk '{print $12}')
     fi
 
     ip addr show "$vf_interface"


### PR DESCRIPTION
We have found some issues with VF detection in cases where interfaces name went from eth10 onwards. With '\*', instead of one interface taken, the 'find' command would take eth1 but also eth10, eth11, etc. Removed '\*' to make sure only one interface is saved