### PR TITLE
Fixed NET Gen2 testcases to return skipped instead of aborted

### DIFF
--- a/Testscripts/Windows/NET-Boot-NoNIC-HotAdd-NIC.ps1
+++ b/Testscripts/Windows/NET-Boot-NoNIC-HotAdd-NIC.ps1
@@ -32,7 +32,7 @@ function Main {
     $vm = Get-VM -Name $VMName -ComputerName $HvServer -ErrorAction SilentlyContinue
     if ($vm.Generation -ne 2) {
         Write-LogWarn "This test requires a Gen2 VM."
-        return "ABORTED"
+        return "SKIPPED"
     }
 
     # Verify Windows Server version

--- a/Testscripts/Windows/NET-HotAdd-MultiNIC.ps1
+++ b/Testscripts/Windows/NET-HotAdd-MultiNIC.ps1
@@ -44,7 +44,7 @@ function Main {
     $vm = Get-VM -Name $VMName -ComputerName $HvServer -ErrorAction SilentlyContinue
     if ($vm.Generation -ne 2) {
         Write-LogWarn "This test requires a Gen2 VM."
-        return "ABORTED"
+        return "SKIPPED"
     }
 
     # Verify Windows Server version

--- a/Testscripts/Windows/NET-HotAddRemove-Max-NIC.ps1
+++ b/Testscripts/Windows/NET-HotAddRemove-Max-NIC.ps1
@@ -51,7 +51,7 @@ function Main {
     $vm = Get-VM -Name $VMName -ComputerName $HvServer -ErrorAction SilentlyContinue
     if ($vm.Generation -ne 2) {
         Write-LogWarn "This test requires a Gen2 VM."
-        return "ABORTED"
+        return "SKIPPED"
     }
 
     # Verify Windows Server version


### PR DESCRIPTION
Network Gen2  test cases should return skipped on Gen1 VM