### PR TITLE
HyperV.psm1: Added the hostname in /etc/hosts

### DIFF
--- a/Libraries/HyperV.psm1
+++ b/Libraries/HyperV.psm1
@@ -535,7 +535,8 @@ Function Inject-HostnamesInHyperVVMs($allVMData)
         {
             Write-LogInfo "Injecting hostname '$($VM.RoleName)' in HyperV VM..."
             if (!$global:IsWindowsImage) {
-               Run-LinuxCmd -username $user -password $password -ip $VM.PublicIP -port $VM.SSHPort -command "echo $($VM.RoleName) > /etc/hostname" -runAsSudo -maxRetryCount 5
+                Run-LinuxCmd -username $user -password $password -ip $VM.PublicIP -port $VM.SSHPort `
+                    -command "echo $($VM.RoleName) > /etc/hostname ; sed -i `"/127/s/`$/ $($VM.RoleName)/`" /etc/hosts" -runAsSudo -maxRetryCount 5
             } else {
                 $cred = Get-Cred $user $password
                 Invoke-Command -ComputerName $VM.PublicIP -ScriptBlock {$computerInfo=Get-ComputerInfo;if($computerInfo.CsDNSHostName -ne $args[0]){Rename-computer -computername $computerInfo.CsDNSHostName -newname $args[0] -force}} -ArgumentList $VM.RoleName -Credential $cred


### PR DESCRIPTION
Until now, the hostname was only injected in /etc/hostname. In some cases, if the hostname present in /etc/hosts and /etc/hostname don't match, an error (sudo: unable to resolve host) will pop every time
commands are run in sudo in VM. This is breaking a few tests.

## Before the fix:
2/21/2019 08:24:59 : [INFO ] The interface that will be configured on LISAv2-TwoVM1Dep-ubuntuAzuretrusty-SX79-636863052186-dependency-vm is
sudo: unable to resolve host (none)
eth1

## After the fix:
02/21/2019 10:40:48 : [INFO ] The interface that will be configured on LISAv2-TwoVM1Dep-ubAz-VG90-636863133854-dependency-vm is eth1