### PR TITLE
NETWORK: Various fixes for Hyper-V

### DIFF
--- a/Testscripts/Linux/NET-Copy-Large-File.sh
+++ b/Testscripts/Linux/NET-Copy-Large-File.sh
@@ -6,7 +6,7 @@
 #############################################################################################################
 #
 # Description:
-#   This script verifies that the network doesn't loose connection 
+#   This script verifies that the network doesn't lose connection
 #   by copying a large file(~10GB)file between two VM's with IC installed.
 #
 #   Steps:
@@ -51,12 +51,10 @@ if [ "${NETMASK:-UNDEFINED}" = "UNDEFINED" ]; then
     NETMASK=255.255.255.0
 fi
 if [ "$ADDRESS_FAMILY" = "IPv6" ];then
-    LogMsg "AM INTRAT IN IPV6"
     scp_cmd="scp -6"
     ssh_cmd="ssh -6"
     ip_cmd="$remote_user"@"[${STATIC_IP2}]"
 else
-    LogMsg "AM INTRAT IN IPV4"
     scp_cmd="scp"
     ssh_cmd="ssh"
     ip_cmd="$remote_user"@"${STATIC_IP2}"

--- a/Testscripts/Linux/NET-Corruption.sh
+++ b/Testscripts/Linux/NET-Corruption.sh
@@ -43,7 +43,7 @@ function ConfigInterface {
     #Check if ethtool exist and install it if not
     ethtool --version
     if [ $? -ne 0 ]; then
-        install_package "ethtool"  
+        install_package "ethtool"
     fi
 
     # Disable tcp segmentation offload

--- a/Testscripts/Linux/NET-Operstate.sh
+++ b/Testscripts/Linux/NET-Operstate.sh
@@ -14,7 +14,7 @@
 ##############################################################################
 # Source utils.sh
 . utils.sh || {
-    echo "Error: unable to source utils.sh!"
+    echo "unable to source utils.sh!"
     echo "TestAborted" > state.txt
     exit 0
 }
@@ -24,13 +24,13 @@ UtilsInit
 # Parameter provided in constants file
 declare __iface_ignore
 if [ "${ipv4:-UNDEFINED}" = "UNDEFINED" ]; then
-    LogErr "Error: The test parameter ipv4 is not defined in constants file! Make sure you are using the latest LIS code."
+    LogErr "The test parameter ipv4 is not defined in constants file! Make sure you are using the latest LIS code."
     SetTestStateFailed
     exit 0
 else
     CheckIP "$ipv4"
     if [ 0 -ne $? ]; then
-        LogErr "Error: Test parameter ipv4 = $ipv4 is not a valid IP Address"
+        LogErr "Test parameter ipv4 = $ipv4 is not a valid IP Address"
         SetTestStateFailed
         exit 0
     fi
@@ -49,18 +49,18 @@ else
         LogMsg "The only synthetic interface is the one which LIS uses to send files/commands to the VM."
     fi
     LogMsg "Found ${#SYNTH_NET_INTERFACES[@]} synthetic interface(s): ${SYNTH_NET_INTERFACES[*]} in VM"
-   
+
     declare __synth_iface
     for __synth_iface in ${SYNTH_NET_INTERFACES[@]}; do
         if [ ! -e /sys/class/net/"$__synth_iface"/operstate ]; then
-            LogErr "Error: Could not find /sys/class/net/$__synth_iface/operstate ."
+            LogErr "Could not find /sys/class/net/$__synth_iface/operstate ."
             SetTestStateFailed
             exit 0
         fi
 
         __state=$(cat /sys/class/net/"${__synth_iface}"/operstate)
         if [ "$__state" != "down" ]; then
-            LogErr "Error: Operstate of $__synth_iface is not down. It is $__state"
+            LogErr "Operstate of $__synth_iface is not down. It is $__state"
             SetTestStateFailed
             exit 0
         fi
@@ -87,14 +87,14 @@ else
             declare __legacy_iface
             for __legacy_iface in ${LEGACY_NET_INTERFACES[@]}; do
                 if [ ! -e /sys/class/net/"$__legacy_iface"/operstate ]; then
-                    LogErr "Error: Could not find /sys/class/net/$__legacy_iface/operstate ."
+                    LogErr "Could not find /sys/class/net/$__legacy_iface/operstate ."
                     SetTestStateFailed
                     exit 0
                 fi
 
                 __state=$(cat /sys/class/net/"${__legacy_iface}"/operstate)
                 if [ "$__state" != "down" ]; then
-                    LogErr "Error: Operstate of $__legacy_iface is not down. It is $__state"
+                    LogErr "Operstate of $__legacy_iface is not down. It is $__state"
                     SetTestStateFailed
                     exit 0
                 fi
@@ -105,7 +105,7 @@ fi
 
 # test if there was any "check"-able interface at all
 if [ ${#SYNTH_NET_INTERFACES[@]} -eq 0 -a ${#LEGACY_NET_INTERFACES[@]} -eq 0 ]; then
-    LogErr "Error: No suitable test interface found."
+    LogErr "No suitable test interface found."
     SetTestStateFailed
     exit 0
 fi

--- a/Testscripts/Linux/NET-Test-Legacy.sh
+++ b/Testscripts/Linux/NET-Test-Legacy.sh
@@ -19,7 +19,7 @@ declare __iface_ignore
 
 # Source utils.sh
 . utils.sh || {
-    echo "Error: unable to source utils.sh!"
+    echo "unable to source utils.sh!"
     echo "TestAborted" > state.txt
     exit 0
 }
@@ -29,10 +29,10 @@ UtilsInit
 GetDistro
 
 # Check for tulip driver. If it's not present, test will be skipped
-cat /boot/config-$(uname -r) | grep "CONFIG_NET_TULIP=y\|CONFIG_TULIP=m"
+grep "CONFIG_NET_TULIP=y\|CONFIG_TULIP=m" /boot/config-$(uname -r)
 if [ $? -ne 0 ]; then
-    LogErr "Warn: Tulip driver is not configured. Test skipped"
-    SetTestStateAborted
+    LogMsg "Warn: Tulip driver is not configured. Test skipped"
+    SetTestStateSkipped
     exit 0
 fi
 
@@ -43,7 +43,7 @@ else
     # Validate that $SYNTH_STATIC_IP is the correct format
     CheckIP "$SYNTH_STATIC_IP"
     if [ 0 -ne $? ]; then
-        LogErr "Error: Variable SYNTH_STATIC_IP: $SYNTH_STATIC_IP does not contain a valid IPv4 address"
+        LogErr "Variable SYNTH_STATIC_IP: $SYNTH_STATIC_IP does not contain a valid IPv4 address"
         SetTestStateAborted
         exit 0
     fi
@@ -56,7 +56,7 @@ else
     # Validate that $LEGACY_STATIC_IP is the correct format
     CheckIP "$LEGACY_STATIC_IP"
     if [ 0 -ne $? ]; then
-        LogErr "Error: Variable LEGACY_STATIC_IP: $LEGACY_STATIC_IP does not contain a valid IPv4 address"
+        LogErr "Variable LEGACY_STATIC_IP: $LEGACY_STATIC_IP does not contain a valid IPv4 address"
         SetTestStateAborted
         exit 0
     fi
@@ -64,7 +64,7 @@ fi
 
 IFS=',' read -a networkType <<< "$NIC_2"
 if [[ ${networkType[0]} == Legacy* ]] && [ -d /sys/firmware/efi ]; then
-    LogErr "Error: Generation 2 VM does not support LegacyNetworkAdapter, skip test"
+    LogErr "Generation 2 VM does not support LegacyNetworkAdapter, skip test"
     SetTestStateAborted
     exit 0
 fi
@@ -83,7 +83,7 @@ fi
 
 # Parameter provided in constants file
 if [ "${REMOTE_SERVER:-UNDEFINED}" = "UNDEFINED" ]; then
-    LogErr "Error: The mandatory test parameter REMOTE_SERVER is not defined in constants file!"
+    LogErr "The mandatory test parameter REMOTE_SERVER is not defined in constants file!"
     SetTestStateAborted
     exit 0
 fi
@@ -115,13 +115,13 @@ fi
 
 # Parameter provided in constants file
 if [ "${ipv4:-UNDEFINED}" = "UNDEFINED" ]; then
-    LogErr "Error: The test parameter ipv4 is not defined in constants file! Make sure you are using the latest LIS code."
+    LogErr "The test parameter ipv4 is not defined in constants file! Make sure you are using the latest LIS code."
     SetTestStateFailed
     exit 0
 else
     CheckIP "$ipv4"
     if [ 0 -ne $? ]; then
-        LogErr "Error: Test parameter ipv4 = $ipv4 is not a valid IP Address"
+        LogErr "Test parameter ipv4 = $ipv4 is not a valid IP Address"
         SetTestStateFailed
         exit 0
     fi
@@ -169,7 +169,7 @@ fi
 # Retrieve synthetic network interfaces
 GetSynthNetInterfaces
 if [ 0 -ne $? ]; then
-    LogErr "Error: No synthetic network interfaces found"
+    LogErr "No synthetic network interfaces found"
     SetTestStateFailed
     exit 0
 fi
@@ -177,7 +177,7 @@ fi
 # Remove interface if present
 SYNTH_NET_INTERFACES=(${SYNTH_NET_INTERFACES[@]/$__iface_ignore/})
 if [ ${#SYNTH_NET_INTERFACES[@]} -eq 0 ]; then
-    LogErr "Error: The only synthetic interface is the one which LIS uses to send files/commands to the VM."
+    LogErr "The only synthetic interface is the one which LIS uses to send files/commands to the VM."
     SetTestStateAborted
     exit 0
 fi
@@ -195,7 +195,7 @@ for __synth_iterator in "${!SYNTH_NET_INTERFACES[@]}"; do
 done
 
 if [ ${#SYNTH_NET_INTERFACES[@]} -eq  ${#__invalid_positions[@]} ]; then
-    LogErr "Error: No usable synthetic interface remains"
+    LogErr "No usable synthetic interface remains"
     SetTestStateFailed
     exit 0
 fi
@@ -210,7 +210,7 @@ done
 unset __invalid_positions
 
 if [ 0 -eq ${#SYNTH_NET_INTERFACES[@]} ]; then
-    LogErr "Error: This should not have happened. Probable internal error above line $LINENO"
+    LogErr "This should not have happened. Probable internal error above line $LINENO"
     SetTestStateFailed
     exit 0
 fi
@@ -218,7 +218,7 @@ fi
 # Get the legacy netadapter interface
 GetLegacyNetInterfaces
 if [ 0 -ne $? ]; then
-    LogErr "Error: No legacy network interfaces found"
+    LogErr "No legacy network interfaces found"
     SetTestStateFailed
     exit 0
 fi
@@ -226,7 +226,7 @@ fi
 # Remove loopback interface if LO_IGNORE is set
 LEGACY_NET_INTERFACES=(${LEGACY_NET_INTERFACES[@]/$__lo_ignore/})
 if [ ${#LEGACY_NET_INTERFACES[@]} -eq 0 ]; then
-    LogErr "Error: The only legacy interface is the loopback interface lo, which was set to be ignored."
+    LogErr "The only legacy interface is the loopback interface lo, which was set to be ignored."
     SetTestStateAborted
     exit 0
 fi
@@ -234,7 +234,7 @@ fi
 # Remove interface if present
 LEGACY_NET_INTERFACES=(${LEGACY_NET_INTERFACES[@]/$__iface_ignore/})
 if [ ${#LEGACY_NET_INTERFACES[@]} -eq 0 ]; then
-    LogErr "Error: The only legacy interface is the one which LIS uses to send files/commands to the VM."
+    LogErr "The only legacy interface is the one which LIS uses to send files/commands to the VM."
     SetTestStateAborted
     exit 0
 fi
@@ -253,7 +253,7 @@ for __legacy_iterator in "${!LEGACY_NET_INTERFACES[@]}"; do
 done
 
 if [ ${#LEGACY_NET_INTERFACES[@]} -eq  ${#__invalid_positions[@]} ]; then
-    LogErr "Error: No usable legacy interface remains"
+    LogErr "No usable legacy interface remains"
     SetTestStateFailed
     exit 0
 fi
@@ -267,7 +267,7 @@ done
 unset __invalid_positions
 
 if [ 0 -eq ${#LEGACY_NET_INTERFACES[@]} ]; then
-    LogErr "Error: This should not have happened. Probable internal error above line $LINENO"
+    LogErr "This should not have happened. Probable internal error above line $LINENO"
     SetTestStateFailed
     exit 0
 fi
@@ -316,7 +316,7 @@ done
 # If all dhcp requests or ping failed, try to set static ip.
 if [ ${#SYNTH_NET_INTERFACES[@]} -eq $__synth_iterator ]; then
     if [ -z "$SYNTH_STATIC_IP" ]; then
-        LogErr "Error: No static IP Address provided for synthetic interfaces. DHCP failed. Unable to continue..."
+        LogErr "No static IP Address provided for synthetic interfaces. DHCP failed. Unable to continue..."
         SetTestStateFailed
         exit 0
     else
@@ -357,7 +357,7 @@ if [ ${#SYNTH_NET_INTERFACES[@]} -eq $__synth_iterator ]; then
         done
 
         if [ ${#SYNTH_NET_INTERFACES[@]} -eq $__synth_iterator ]; then
-            LogErr "Error: Unable to set neither static address for synthetic interface(s) ${SYNTH_NET_INTERFACES[@]}"
+            LogErr "Unable to set neither static address for synthetic interface(s) ${SYNTH_NET_INTERFACES[@]}"
             SetTestStateFailed
             exit 0
         fi
@@ -411,7 +411,7 @@ done
 if [ ${#LEGACY_NET_INTERFACES[@]} -eq $__legacy_iterator ]; then
     LogMsg "Unable to get address for legacy interface(s) ${LEGACY_NET_INTERFACES[@]} through DHCP"
     if [ -z "$LEGACY_STATIC_IP" ]; then
-        LogErr "Error: No static IP Address provided for legacy interfaces. DHCP failed. Unable to continue..."
+        LogErr "No static IP Address provided for legacy interfaces. DHCP failed. Unable to continue..."
         SetTestStateFailed
         exit 0
     else
@@ -441,7 +441,7 @@ if [ ${#LEGACY_NET_INTERFACES[@]} -eq $__legacy_iterator ]; then
         done
 
         if [ ${#LEGACY_NET_INTERFACES[@]} -eq $__legacy_iterator ]; then
-            LogErr "Error: Unable to set neither static address for legacy interface(s) ${LEGACY_NET_INTERFACES[@]}"
+            LogErr "Unable to set neither static address for legacy interface(s) ${LEGACY_NET_INTERFACES[@]}"
             SetTestStateFailed
             exit 0
         fi

--- a/Testscripts/Linux/NET-Test-Network.sh
+++ b/Testscripts/Linux/NET-Test-Network.sh
@@ -20,13 +20,13 @@
 ###############################################################################
 # Source utils.sh
 . utils.sh || {
-    echo "Error: unable to source utils.sh!"
+    echo "unable to source utils.sh!"
     echo "TestAborted" > state.txt
     exit 0
 }
 # Source net_constants.sh file
 . net_constants.sh || {
-    echo "Error: unable to source net_constants.sh!"
+    echo "unable to source net_constants.sh!"
     echo "TestAborted" > state.txt
     exit 0
 }

--- a/Testscripts/Linux/NET-Test-Promiscuous.sh
+++ b/Testscripts/Linux/NET-Test-Promiscuous.sh
@@ -19,7 +19,7 @@
 #############################################################################################################
 # Source utils.sh
 . utils.sh || {
-    echo "Error: unable to source utils.sh!"
+    echo "unable to source utils.sh!"
     echo "TestAborted" > state.txt
     exit 0
 }
@@ -55,7 +55,7 @@ if [ "${NETMASK:-UNDEFINED}" = "UNDEFINED" ]; then
 fi
 
 if [ "${REMOTE_SERVER:-UNDEFINED}" = "UNDEFINED" ]; then
-    LogMsg "Error: The test parameter REMOTE_SERVER is not defined in constants file. No network connectivity test will be performed."
+    LogMsg "The test parameter REMOTE_SERVER is not defined in constants file. No network connectivity test will be performed."
     SetTestStateAborted
     exit 0
 fi
@@ -233,7 +233,7 @@ for __iterator in ${!SYNTH_NET_INTERFACES[@]}; do
             LogMsg "Warning! Failed to set default gateway!"
         fi
     fi
-    
+
     # ping the remote server
     LogMsg "Trying to ping $REMOTE_SERVER"
     "$pingVersion" -I ${SYNTH_NET_INTERFACES[$__iterator]} -c 10 "$REMOTE_SERVER"

--- a/Testscripts/Linux/NET-Verify-Boot-NoNIC.sh
+++ b/Testscripts/Linux/NET-Verify-Boot-NoNIC.sh
@@ -11,20 +11,20 @@ fi
 chmod 755 ./kvp_client64
 
 # Verify there are no eth devices
-echo "Info : Check count of eth devices"
+echo "Check count of eth devices"
 ethCount=$(ls -d /sys/class/net/eth* | wc -l)
-echo "Info : ethCount = ${ethCount}"
+echo "ethCount = ${ethCount}"
 if [ $ethCount -ne 0 ]; then
     echo "eth device count is not zero: ${ethCount}"
     exit 0
 fi
 
 # Create a nonintrinsic HotAddTest KVP item with a value of 'NoNICs'
-echo "Info : Creating HotAddTest key with value of 'NoNICS'"
+echo "Creating HotAddTest key with value of 'NoNICS'"
 ./kvp_client64 append 1 'HotAddTest' 'NoNICs'
 
 # Loop waiting for an eth device to appear
-echo "Info : Waiting for an eth device to appear"
+echo "Waiting for an eth device to appear"
 timeout=300
 noEthDevice=1
 while [ $noEthDevice -eq 1 ]
@@ -48,28 +48,28 @@ ifup eth0
 sleep 60
 
 # Verify the eth device received an IP address
-echo "Info : Verify the new NIC received an IPv4 address"
+echo "Verify the new NIC received an IPv4 address"
 ip addr show eth0 | grep "inet\b"
 if [ $? -ne 0 ]; then
     echo "eth0 was not assigned an IPv4 address"
     exit 0
 fi
 
-echo "Info : eth0 is up"
+echo "eth0 is up"
 
 # Modify the KVP HotAddTest value to 'NICUp'
-echo "Info : Updating HotAddTest KVP item to 'NICUp'"
+echo "Updating HotAddTest KVP item to 'NICUp'"
 ./kvp_client64 append 1 'HotAddTest' 'NICUp'
 
 # Loop waiting for the eth device to be removed
-echo "Info : Waiting for the eth device to be deleted"
+echo "Waiting for the eth device to be deleted"
 timeout=300
 noEthDevice=1
 while [ $noEthDevice -eq 1 ]
 do
     ethCount=$(ls -d /sys/class/net/eth* | wc -l)
     if [ $ethCount -eq 0 ]; then
-        echo "Info : eth count is zero"
+        echo "eth count is zero"
         break
     fi
 
@@ -82,7 +82,7 @@ do
 done
 
 # Modify the KVP HotAddTest value to 'NoNICs'
-echo "Info : Setting HotAddTest value to 'NoNICs'"
+echo "Setting HotAddTest value to 'NoNICs'"
 ./kvp_client64 append 1 'HotAddTest' 'NoNICs'
-echo "Info : Test complete - exiting"
+echo "Test complete - exiting"
 exit 0

--- a/Testscripts/Linux/NET-Verify-HotAdd-MultiNIC.sh
+++ b/Testscripts/Linux/NET-Verify-HotAdd-MultiNIC.sh
@@ -4,7 +4,7 @@
 # Licensed under the Apache License.
 
 . utils.sh || {
-    echo "Error: unable to source utils.sh!"
+    echo "unable to source utils.sh!"
     exit 0
 }
 
@@ -17,7 +17,7 @@ function Add_Nic {
     eth_count=$1
     eth_name=$2
 
-    LogMsg "Info : Checking the eth_count"
+    LogMsg "Checking the eth_count"
     if [ $eth_count -ne 2 ]; then
         LogErr "VM should have two NICs now"
         SetTestStateAborted

--- a/Testscripts/Linux/utils.sh
+++ b/Testscripts/Linux/utils.sh
@@ -1260,6 +1260,9 @@ CreateIfupConfigFile()
 
 				ip link set "$__interface_name" up
 				service networking restart || service network restart
+				if $(ifup --help > /dev/null 2>&1) ; then
+					ifup "$__interface_name"
+				fi
 				;;
 			*)
 				LogMsg "CreateIfupConfigFile: Platform not supported yet!"
@@ -1419,6 +1422,9 @@ CreateIfupConfigFile()
 
 				ip link set "$__interface_name" up
 				service networking restart || service network restart
+				if $(ifup --help > /dev/null 2>&1) ; then
+					ifup "$__interface_name"
+				fi
 				;;
 			*)
 				LogMsg "CreateIfupConfigFile: Platform not supported!"

--- a/Testscripts/Windows/NET-File-Copy-SCP.ps1
+++ b/Testscripts/Windows/NET-File-Copy-SCP.ps1
@@ -39,7 +39,7 @@ function Connect-Disk {
     $driveName = "/dev/sdc"
 
     $null = Run-LinuxCmd -username $VMUser -password $VMPassword -ip $IPv4 `
-        -port $VMPort -command "(echo d;echo;echo w)|fdisk ${driveName}"
+        -port $VMPort -command "(echo d;echo;echo w)|fdisk ${driveName}" -ignoreLinuxExitCode:$true
     if (-not $?) {
         Write-LogErr "Failed to format the disk in the VM"
         return $False
@@ -143,6 +143,8 @@ function Main {
         $VMPassword
     )
     $guestUsername = "root"
+
+    Provision-VMsForLisa -allVMData $AllVMData -installPackagesOnRoleNames none
     # 10GB file size
     $filesize1 = 10737418240
     # 10GB file size

--- a/Testscripts/Windows/NET-Test-Private-Network.ps1
+++ b/Testscripts/Windows/NET-Test-Private-Network.ps1
@@ -68,7 +68,7 @@ function Main {
     # Switch network connection type in case is needed
     if ($switchNic) {
         # Switch the NIC on test VM from External to Private
-        $retVal = .\Testscripts\Windows\SETUP-NET-Switch-NIC.ps1 -AllVMData $AllVMData -testParams "SWITCH=$switchNic"
+        $retVal = .\Testscripts\Windows\SETUP-NET-Switch-NIC.ps1 -VMName $VMName -testParams "SWITCH=$switchNic"
         if (-not $retVal) {
             Write-LogErr "Failed to switch connection type for $VMName on $HvServer"
             return "FAIL"
@@ -76,7 +76,7 @@ function Main {
 
         # Switch the NIC on dependency VM from External to Private
         $switchNic = $switchNic+","+$vm2MacAddress
-        $retVal = .\Testscripts\Windows\SETUP-NET-Switch-NIC.ps1 -AllVMData $AllVMData -testParams "SWITCH=$switchNic"
+        $retVal = .\Testscripts\Windows\SETUP-NET-Switch-NIC.ps1 -VMName $VM2Name -testParams "SWITCH=$switchNic"
         if (-not $retVal) {
             Write-LogErr "Failed to switch connection type for $VM2Name on $HvServer"
             return "FAIL"

--- a/Testscripts/Windows/SETUP-NET-Switch-NIC.ps1
+++ b/Testscripts/Windows/SETUP-NET-Switch-NIC.ps1
@@ -3,10 +3,12 @@
 
 <#
 .Synopsis
- Switch an existing NIC (with a certain MAC address) to a different network.
+    Switch an existing NIC (with a certain MAC address) to a different network.
 #>
 
-param([string] $TestParams, [object] $AllVMData)
+param([string] $TestParams,
+    [object] $AllVMData,
+    [string] $VMName)
 
 function Main {
     param (
@@ -76,7 +78,7 @@ function Main {
             }
 
             # Get NIC with given MAC Address
-            $nic = Get-VMNetworkAdapter -VMName $vmName -ComputerName $hvServer -IsLegacy:$legacy | where {$_.MacAddress -eq $macAddress }
+            $nic = Get-VMNetworkAdapter -VMName $VMName -ComputerName $hvServer -IsLegacy:$legacy | where {$_.MacAddress -eq $macAddress }
             if ($nic) {
                 if ($networkType -like "None") {
                     Disconnect-VMNetworkAdapter $nic
@@ -86,7 +88,7 @@ function Main {
 
                 $retVal = $?
             } else {
-                Write-LogErr "Error: $vmName - No NIC found with MAC $macAddress ."
+                Write-LogErr "Error: $VMName - No NIC found with MAC $macAddress ."
             }
         }
     }
@@ -95,5 +97,8 @@ function Main {
     return $retVal
 }
 
-Main -VMName $AllVMData.RoleName -hvServer $GlobalConfig.Global.Hyperv.Hosts.ChildNodes[0].ServerName `
+if (-not $VMName) {
+    $VMName = $AllVMData.RoleName
+}
+Main -VMName $VMName -hvServer $GlobalConfig.Global.Hyperv.Hosts.ChildNodes[0].ServerName `
          -TestParams $TestParams


### PR DESCRIPTION
Network tests had multiple fails on Hyper-V. This is fixing the
following:
- In Ubuntu 14.04, the 'ip link set dev INTERFACE up' doesn't work.
Added extra ifup check & ifup INTERFACE to consolidate this.
- Replaced Aborted with Skip state for Legacy and Max NICs tests if
tulip driver is not configured in kernel
- Fixed Switch Interface test cases. They only received the AllVMData
object, not a specific VMName to be set up.
- Enabled root for File Copy SCP.
- Various message fixes