### PR TITLE
Disable automatic checkpoints on Hyper-V VMs

### DIFF
--- a/Libraries/HyperV.psm1
+++ b/Libraries/HyperV.psm1
@@ -355,6 +355,10 @@ function Create-HyperVGroupDeployment([string]$HyperVGroupName, $HyperVGroupXML,
                     Write-LogInfo "Set-VMFirmware -VMName $CurrentVMName -EnableSecureBoot Off"
                     Set-VMFirmware -VMName $CurrentVMName -EnableSecureBoot Off
                 }
+                if ($NewVM.AutomaticCheckpointsEnabled) {
+                    Write-LogInfo "Set-VM -Name $CurrentVMName -AutomaticCheckpointsEnabled $false -ComputerName $HyperVHost"
+                    Set-VM -Name $CurrentVMName -AutomaticCheckpointsEnabled $false -ComputerName $HyperVHost
+                }
                 if ($currentTestData.AdditionalHWConfig.SwitchName) {
                     Add-VMNetworkAdapter -VMName $CurrentVMName -SwitchName $currentTestData.AdditionalHWConfig.SwitchName -ComputerName $HyperVHost
                 }


### PR DESCRIPTION
Automatic checkpoints are enabled by default Hyper-V on the new Windows 10 builds (Creators update) and this means Hyper-V will create checkpoints independently outside of the framework.
This is a fix/workaround to disable automatic checkpoints on the VM right after the it is created.

Reference: https://blogs.technet.microsoft.com/virtualization/2017/04/20/making-it-easier-to-revert/