### PR TITLE
HyperV: Abort TC if the server is not in a cluster

### DIFF
--- a/Libraries/HyperV.psm1
+++ b/Libraries/HyperV.psm1
@@ -342,6 +342,9 @@ function Create-HyperVGroupDeployment([string]$HyperVGroupName, $HyperVGroupXML,
             $vhdName = [System.IO.Path]::GetFileNameWithoutExtension($(Split-Path -Leaf $parentOsVHDPath))
             Write-LogInfo "Checking if we have a local VHD with the same disk identifier on the host"
             $hypervVHDLocalPath = (Get-VMHost -ComputerName $HyperVHost).VirtualHardDiskPath
+            if ($SetupTypeData.ClusteredVM) {
+                $hypervVHDLocalPath = $DestinationOsVHDPath
+            }
             $newVhdName = "{0}-{1}{2}" -f @($vhdName, $infoParentOsVHD.DiskIdentifier.Replace("-", ""),$vhdSuffix)
             $localVHDPath = Join-Path $hypervVHDLocalPath $newVhdName
             $localVHDUncPath = $localVHDPath -replace '^(.):', "\\${HyperVHost}\`$1$"

--- a/Libraries/HyperV.psm1
+++ b/Libraries/HyperV.psm1
@@ -43,12 +43,7 @@ function Create-AllHyperVGroupDeployments($SetupTypeData, $GlobalConfig, $TestLo
             $HyperVHostArray += $GlobalConfig.Global.HyperV.Hosts.ChildNodes[$index].ServerName
         }
 
-        if ($SetupTypeData.ClusteredVM) {
-            $ClusterVolume = Get-ClusterSharedVolume
-            $DestinationOsVHDPath = $ClusterVolume.SharedVolumeInfo.FriendlyVolumeName
-        } else {
-            $DestinationOsVHDPath = $GlobalConfig.Global.HyperV.Hosts.ChildNodes[$index].DestinationOsVHDPath
-        }
+        $DestinationOsVHDPath = $GlobalConfig.Global.HyperV.Hosts.ChildNodes[$index].DestinationOsVHDPath
         $index++
         $readyToDeploy = $false
         while (!$readyToDeploy)
@@ -267,6 +262,24 @@ function Create-HyperVGroup([string]$HyperVGroupName, [string]$HyperVHost) {
     return $retValue
 }
 
+function Get-ClusterVolumePath {
+	param(
+		$ComputerName
+	)
+	$invokeCommandParams = @{
+		"ScriptBlock" = {
+			$ClusterVolume = Get-ClusterSharedVolume -ErrorAction SilentlyContinue
+			if ($ClusterVolume) {
+				Write-Output $ClusterVolume.SharedVolumeInfo.FriendlyVolumeName
+			}
+		};
+	}
+	if ($ComputerName -ne "localhost" -and $ComputerName -ne $(hostname)) {
+		$invokeCommandParams.ComputerName = $ComputerName
+	}
+	return (Invoke-Command @invokeCommandParams)
+}
+
 function Create-HyperVGroupDeployment([string]$HyperVGroupName, $HyperVGroupXML, $HyperVHost, $DestinationOsVHDPath, $VMGeneration,
     $GlobalConfig, $SetupTypeData, $CurrentTestData) {
     $HyperVMappedSizes = [xml](Get-Content .\XML\AzureVMSizeToHyperVMapping.xml)
@@ -280,13 +293,17 @@ function Create-HyperVGroupDeployment([string]$HyperVGroupName, $HyperVGroupXML,
             if ($VirtualMachine.DeployOnDifferentHyperVHost -and ($TestLocation -match ",")) {
                 $hostNumber = $HyperVGroupXML.VirtualMachine.indexOf($VirtualMachine)
                 $HyperVHost = $GlobalConfig.Global.HyperV.Hosts.ChildNodes[$hostNumber].ServerName
-                if ($SetupTypeData.ClusteredVM) {
-                    $ClusterVolume = Get-ClusterSharedVolume
-                    $DestinationOsVHDPath = $ClusterVolume.SharedVolumeInfo.FriendlyVolumeName
-                } else {
-                    $DestinationOsVHDPath = $GlobalConfig.Global.HyperV.Hosts.ChildNodes[$hostNumber].DestinationOsVHDPath
+                $DestinationOsVHDPath = $GlobalConfig.Global.HyperV.Hosts.ChildNodes[$hostNumber].DestinationOsVHDPath
+            }
+            if ($SetupTypeData.ClusteredVM) {
+                $DestinationOsVHDPath = Get-ClusterVolumePath -ComputerName $HyperVHost
+                if (!$DestinationOsVHDPath) {
+                    Write-LogErr "ClusterVolume could not be found. Make sure that server ${HyperVHost} has clustering enabled."
+                    $ErrorCount += 1
+                    continue
                 }
             }
+
             $vhdSuffix = [System.IO.Path]::GetExtension($OsVHD)
             $InterfaceAliasWithInternet = (Get-NetIPConfiguration -ComputerName $HyperVHost | Where-Object {$_.NetProfile.Name -ne 'Unidentified network'}).InterfaceAlias
             $VMSwitches = Get-VMSwitch -ComputerName $HyperVHost | Where-Object {$InterfaceAliasWithInternet -match $_.Name} | Select-Object -First 1
@@ -387,10 +404,19 @@ function Create-HyperVGroupDeployment([string]$HyperVGroupName, $HyperVGroupXML,
                 $ErrorCount += 1
             }
             if ($SetupTypeData.ClusteredVM) {
-                Move-VMStorage $CurrentVMName -DestinationStoragePath $DestinationOsVHDPath
-                Add-ClusterVirtualMachineRole -VirtualMachine $CurrentVMName
+                Move-VMStorage -Name $CurrentVMName -DestinationStoragePath $DestinationOsVHDPath -ComputerName $HyperVHost
+                $invokeCommandParams = @{
+                    "ScriptBlock" = {
+                        Add-ClusterVirtualMachineRole -VirtualMachine $args[0]
+                    };
+                    "ArgumentList" = $CurrentVMName;
+                }
+                if ($HyperVHost -ne "localhost" -and $HyperVHost -ne $(hostname)) {
+                    $invokeCommandParams.ComputerName = $HyperVHost
+                }
+                Invoke-Command @invokeCommandParams
                 if ($? -eq $False) {
-                    Write-LogErr "High Availability configure for VM ${CurrentVMName} could not be added to the Hyper-V cluster"
+                    Write-LogErr "High Availability VM ${CurrentVMName} could not be added to the Hyper-V cluster on ${HyperVHost}"
                     $ErrorCount += 1
                 }
             }


### PR DESCRIPTION
On HyperV platform, if any live migration test is run on a non-clustered environment, LISAv2 exits with 1 and does not continue with running the remaining test cases.

This patch fixes the above issue and makes sure the parent vhd is cached in the cluster storage directory so that live migration succeeds.

**LISAv2 is required to run on a cluster node, otherwise, credssp and username/password needs to be provided somehow (and there is no support yet in the framework for this feature).** 

**Multiple live migration test cases need to be run with LISAV2 flag: -DeployVMPerEachTest:$true, otherwise only the first one will PASS.**

Execution tested:

```
VHD Under Test        : ubuntu_18.04.1\ubuntu_18.04.1.vhdx
Test Area             : MIGRATION
Total Test Cases      : 10 (10 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:53

   ID TestCaseName                                                                TestResult TestDuration(in minutes)
---------------------------------------------------------------------------------------------------------------------
    1 LIVE-MIGRATE                                                                      PASS                 0.47
    2 LIVE-MIGRATE-FAILOVER                                                             PASS                 1.49
    3 LIVE-MIGRATE-MEM4GB-CORE8                                                         PASS                 2.92
    4 LIVE-MIGRATE-MEM8GB-CORE16                                                        PASS                 3.48
    5 LIVE-MIGRATE-MEM16GB-CORE32                                                       PASS                 4.49
    6 LIVE-MIGRATE-QUICK-MIGRATE                                                        PASS                 1.48
    7 LIVE-MIGRATE-COPYFILE-DURING-MIGRATION                                            PASS                 1.61
    8 LIVE-MIGRATE-QUICKMIG-MEM4GB-CORE8                                                PASS                 2.94
    9 LIVE-MIGRATE-QUICKMIG-MEM8GB-CORE16                                               PASS                 3.45
   10 LIVE-MIGRATE-QUICKMIG-MEM16GB-CORE32                                              PASS                 4.61
```