### PR TITLE
Testscripts: Various fixes in bash scripts

### DIFF
--- a/Testscripts/Linux/CORE-CPUVerifyOnline.sh
+++ b/Testscripts/Linux/CORE-CPUVerifyOnline.sh
@@ -8,9 +8,6 @@
 #	the /proc/cpuinfo file.
 #	The VM is configured with 4 CPU cores as part of the setup script,
 #	as each core can't be offline except vcpu0 for a successful test pass.
-
-CONSTANTS_FILE="constants.sh"
-
 . utils.sh || {
     echo "unable to source utils.sh!"
     echo "TestAborted" > state.txt
@@ -19,21 +16,12 @@ CONSTANTS_FILE="constants.sh"
 
 UtilsInit
 
-# Source the constants file
-if [ -e ./${CONSTANTS_FILE} ]; then
-    source ${CONSTANTS_FILE}
-else
-    LogErr "no ${CONSTANTS_FILE} file"
-    SetTestStateFailed
-    exit 0
-fi
-
 # Getting the CPUs count
 cpu_count=$(grep -i processor -o /proc/cpuinfo | wc -l)
 UpdateSummary "${cpu_count} CPU cores detected"
 
 #
-# Verifying all CPUs can't be offline except CPU0 
+# Verifying all CPUs can't be offline except CPU0
 #
 for ((cpu=1 ; cpu<=$cpu_count ; cpu++)) ;do
     LogMsg "Checking the $cpu on /sys/device/...."

--- a/Testscripts/Linux/NET-Copy-Large-File.sh
+++ b/Testscripts/Linux/NET-Copy-Large-File.sh
@@ -120,7 +120,7 @@ fi
 
 # Check disk size on local vm
 LogMsg "Checking for local disk space"
-IsFreeSpace "$HOME" "$file_size"
+IsFreeSpace "/home/${SUDO_USER}" "$file_size"
 if [ 0 -ne $? ]; then
     LogErr "Not enough free space on current partition to create the test file"
     SetTestStateFailed
@@ -130,14 +130,14 @@ LogMsg "Enough free space locally to create the file"
 
 LogMsg "Checking for disk space on $STATIC_IP2"
 # Check disk size on remote vm. Cannot use IsFreeSpace function directly. Need to export utils.sh to the remote_vm, source it and then access the functions therein
-$scp_cmd -i "$HOME"/.ssh/"$SSH_PRIVATE_KEY" -o StrictHostKeyChecking=no utils.sh $ip_cmd:/tmp
+$scp_cmd -i "/home/${SUDO_USER}"/.ssh/"$SSH_PRIVATE_KEY" -o StrictHostKeyChecking=no utils.sh $ip_cmd:/tmp
 if [ 0 -ne $? ]; then
     LogErr "Cannot copy utils.sh to $STATIC_IP2:/tmp"
     SetTestStateFailed
     exit 0
 fi
 
-remote_home=$($ssh_cmd -i "$HOME"/.ssh/"$SSH_PRIVATE_KEY" -o StrictHostKeyChecking=no "$remote_user"@"$STATIC_IP2" "
+remote_home=$($ssh_cmd -i "/home/${SUDO_USER}"/.ssh/"$SSH_PRIVATE_KEY" -o StrictHostKeyChecking=no "$remote_user"@"$STATIC_IP2" "
     . /tmp/utils.sh
     IsFreeSpace \"\$HOME\" $file_size
     if [ 0 -ne \$? ]; then
@@ -171,15 +171,15 @@ else
 fi
 # create file locally with PID appended
 output_file=large_file_$$
-if [ -d "$HOME"/"$output_file" ]; then
-    rm -rf "$HOME"/"$output_file"
+if [ -d "/home/${SUDO_USER}"/"$output_file" ]; then
+    rm -rf "/home/${SUDO_USER}"/"$output_file"
 fi
 
-if [ -e "$HOME"/"$output_file" ]; then
-    rm -f "$HOME"/"$output_file"
+if [ -e "/home/${SUDO_USER}"/"$output_file" ]; then
+    rm -f "/home/${SUDO_USER}"/"$output_file"
 fi
 
-dd if=$file_source of="$HOME"/"$output_file" bs=1M count=$((file_size/1024/1024))
+dd if=$file_source of="/home/${SUDO_USER}"/"$output_file" bs=1M count=$((file_size/1024/1024))
 if [ 0 -ne $? ]; then
     LogErr "Unable to create file $output_file in $HOME"
     SetTestStateFailed
@@ -191,9 +191,9 @@ LogMsg "Successfully created $output_file"
 local_md5sum=$(md5sum $output_file | cut -f 1 -d ' ')
 
 # send file to remote_vm
-$scp_cmd -i "$HOME"/.ssh/"$SSH_PRIVATE_KEY" -o StrictHostKeyChecking=no "$output_file" $ip_cmd:"$remote_home"/"$output_file"
+$scp_cmd -i "/home/${SUDO_USER}"/.ssh/"$SSH_PRIVATE_KEY" -o StrictHostKeyChecking=no "$output_file" $ip_cmd:"$remote_home"/"$output_file"
 if [ 0 -ne $? ]; then
-    [ $NO_DELETE -eq 0 ] && rm -f "$HOME"/$output_file
+    [ $NO_DELETE -eq 0 ] && rm -f "/home/${SUDO_USER}"/$output_file
     LogErr "Unable to copy file $output_file to $STATIC_IP2:$remote_home/$output_file"
     SetTestStateFailed
     exit 0
@@ -204,10 +204,10 @@ LogMsg "Successfully sent $output_file to $STATIC_IP2:$remote_home/$output_file"
 [ $NO_DELETE -eq 0 ] && rm -f $output_file
 
 # copy file back from remote vm
-$scp_cmd -i "$HOME"/.ssh/"$SSH_PRIVATE_KEY" -o StrictHostKeyChecking=no $ip_cmd:"$remote_home"/"$output_file" "$HOME"/"$output_file"
+$scp_cmd -i "/home/${SUDO_USER}"/.ssh/"$SSH_PRIVATE_KEY" -o StrictHostKeyChecking=no $ip_cmd:"$remote_home"/"$output_file" "/home/${SUDO_USER}"/"$output_file"
 if [ 0 -ne $? ]; then
     #try to erase file from remote vm
-    [ $NO_DELETE -eq 0 ] && $ssh_cmd -i "$HOME"/.ssh/"$SSH_PRIVATE_KEY" -o StrictHostKeyChecking=no "$remote_user"@"$STATIC_IP2" "rm -f \$HOME/$output_file"
+    [ $NO_DELETE -eq 0 ] && $ssh_cmd -i "/home/${SUDO_USER}"/.ssh/"$SSH_PRIVATE_KEY" -o StrictHostKeyChecking=no "$remote_user"@"$STATIC_IP2" "rm -f \$HOME/$output_file"
     LogErr "Unable to copy from $STATIC_IP2:$remote_home/$output_file"
     SetTestStateFailed
     exit 0
@@ -215,20 +215,20 @@ fi
 LogMsg "Received $output_file from $STATIC_IP2"
 
 # delete remote file
-[ $NO_DELETE -eq 0 ] && $ssh_cmd -i "$HOME"/.ssh/"$SSH_PRIVATE_KEY" -o StrictHostKeyChecking=no "$remote_user"@"$STATIC_IP2" "rm -f $remote_home/$output_file"
+[ $NO_DELETE -eq 0 ] && $ssh_cmd -i "/home/${SUDO_USER}"/.ssh/"$SSH_PRIVATE_KEY" -o StrictHostKeyChecking=no "$remote_user"@"$STATIC_IP2" "rm -f $remote_home/$output_file"
 
 # check md5sums
 remote_md5sum=$(md5sum $output_file | cut -f 1 -d ' ')
 
 if [ "$local_md5sum" != "$remote_md5sum" ]; then
-    [ $NO_DELETE -eq 0 ] && rm -f "$HOME"/$output_file
+    [ $NO_DELETE -eq 0 ] && rm -f "/home/${SUDO_USER}"/$output_file
     LogErr "md5sums differ. Files do not match"
     SetTestStateFailed
     exit 0
 fi
 
 # delete local file again
-[ $NO_DELETE -eq 0 ] && rm -f "$HOME"/$output_file
+[ $NO_DELETE -eq 0 ] && rm -f "/home/${SUDO_USER}"/$output_file
 
 LogMsg "Updating test case state to completed"
 SetTestStateCompleted

--- a/Testscripts/Linux/STOR-Large-CopyFile.sh
+++ b/Testscripts/Linux/STOR-Large-CopyFile.sh
@@ -152,18 +152,6 @@ function Test_File_System_Copy() {
     fi
 }
 
-# Source the constants file
-if [ -e ~/${CONSTANTS_FILE} ]; then
-    source ~/${CONSTANTS_FILE}
-else
-    LogErr "Error: in ${CONSTANTS_FILE} file"
-    SetTestStateFailed
-    exit 0
-fi
-
-# Create the state.txt file so ICA knows we are running
-SetTestStateRunning
-
 # Check for call trace log
 ./check_traces.sh &
 

--- a/Testscripts/Linux/STORAGE-HotRemove.sh
+++ b/Testscripts/Linux/STORAGE-HotRemove.sh
@@ -2,8 +2,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the Apache License.
 
-CONSTANTS_FILE="constants.sh"
-
 . utils.sh || {
     echo "Error: unable to source utils.sh!"
     exit 0
@@ -11,23 +9,10 @@ CONSTANTS_FILE="constants.sh"
 
 UtilsInit
 
-# Create the state.txt file so ICA knows we are running
-LogMsg "Updating test case state to running"
-SetTestStateRunning
-
-# Source the constants file
-if [ -e ./${CONSTANTS_FILE} ]; then
-    source ${CONSTANTS_FILE}
-else
-    LogErr "no ${CONSTANTS_FILE} file"
-    SetTestStateAborted
-    exit 0
-fi
-
 ./check_traces.sh &
 
 # Count the number of SCSI= and IDE= entries in constants
-if [ -z "$diskCount" ];  then
+if [ -z "$diskCount" ]; then
     diskCount=0
     for entry in $(cat ./constants.sh)
     do
@@ -50,7 +35,7 @@ fi
 LogMsg "constants disk count = $diskCount"
 
 ### do fdisk to rescan the scsi bus
-for i in {1..4};do 
+for i in {1..4}; do
     echo $i
     fdisk -l > /dev/null
 done

--- a/Testscripts/Linux/STORAGE-LargeDisk.sh
+++ b/Testscripts/Linux/STORAGE-LargeDisk.sh
@@ -2,8 +2,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the Apache License.
 
-CONSTANTS_FILE="constants.sh"
-
 function Check_For_Error() {
     distro=$(grep -ihs "Ubuntu\|SUSE\|Fedora\|Debian\|CentOS\|Red Hat Enterprise Linux" /etc/{issue,*release,*version})
     if [[ $distro = *"ubuntu"* || $distro = *"debian"* ]]; then
@@ -37,7 +35,7 @@ function Integrity_Check() {
     blocks=$((blocks-1))
     mount "$targetDevice" /mnt/
     targetDevice="/mnt/1"
-    
+
     LogMsg "Creating test data file $testfile with size $blockSize"
     LogMsg "Creating test source file... ($blockSize)"
 
@@ -52,7 +50,7 @@ function Integrity_Check() {
     for ((y=0 ; y<blocks ; y++)) ; do
         LogMsg "Writing block $y to device $targetDevice ..."
         dd if=$testFile of=$targetDevice bs=$blockSize count=1 seek=$y status=noxfer 2> /dev/null
-        
+
         LogMsg "Checking block $y ..."
         testChecksum=$(dd if=$targetDevice bs=$blockSize count=1 skip=$y status=noxfer 2> /dev/null | sha1sum | cut -d " " -f 1)
         if [ "$checksum" == "$testChecksum" ] ; then
@@ -63,7 +61,7 @@ function Integrity_Check() {
             exit 0
         fi
     done
-    
+
     UpdateSummary "Data integrity test on ${blocks} blocks on drive $1 : success"
     umount /mnt/
     rm -f $testFile
@@ -75,12 +73,12 @@ function Test_File_System() {
     fs=$2
     parted -s -- "$drive" mklabel gpt
     parted -s -- "$drive" mkpart primary 64s -64s
-    
+
     if [ "$?" = "0" ]; then
         sleep 5
         wipefs -a "${driveName}1"
         Check_For_Error "${driveName}1" &
-        
+
         # Integrity_Check $driveName
         mkfs."$fs" "${driveName}1"
         if [ "$?" = "0" ]; then
@@ -127,18 +125,6 @@ function Test_File_System() {
 }
 
 UtilsInit
-
-# Source the constants file
-if [ -e ~/${CONSTANTS_FILE} ]; then
-    source ~/${CONSTANTS_FILE}
-else
-    LogErr "in ${CONSTANTS_FILE} file"
-    SetTestStateAborted
-    exit 0
-fi
-
-# Create the state.txt file so ICA knows we are running
-SetTestStateRunning
 
 # Count the number of SCSI= and IDE= entries in constants
 diskCount=0
@@ -194,7 +180,7 @@ do
     if [ "${driveName}" = "/dev/sda" ] || [ "${driveName}" = "/dev/sdb" ]; then
         continue
     fi
-    
+
     for fs in "${fileSystems[@]}"; do
         LogMsg "Start testing filesystem: $fs"
         StartTst=$(date +%s.%N)

--- a/Testscripts/Linux/Sysbench.sh
+++ b/Testscripts/Linux/Sysbench.sh
@@ -12,7 +12,6 @@
 #
 #   No optional parameters needed
 
-CONSTANTS_FILE="constants.sh"
 ROOT_DIR="/root"
 
 # For changing Sysbench version only the following parameter has to be changed
@@ -50,7 +49,7 @@ function File_Io ()
 {
     sysbench fileio --num-threads=1 --file-test-mode=$1 prepare > /dev/null 2>&1
     LogMsg "Preparing files to test $1..."
-    
+
     sysbench fileio --num-threads=1 --file-test-mode=$1 run > /root/$1.log
     if [ $? -ne 0 ]; then
         LogErr "Unable to execute sysbench fileio mode $1. Aborting..."
@@ -100,7 +99,7 @@ function Download_Sysbench() {
 
 function Install_Deps() {
     GetDistro
-    
+
     case $OS_FAMILY in
         "Rhel")
             mkdir autoconf
@@ -112,7 +111,7 @@ function Install_Deps() {
             make
             make install
             popd
-            
+
             yum_install "devtoolset-2-binutils automake libtool vim"
             popd
         ;;
@@ -123,7 +122,7 @@ function Install_Deps() {
             zypper_install "vim"
         ;;
     esac
-    
+
     pushd "$ROOT_DIR/sysbench-$SYSBENCH_VERSION"
     bash ./autogen.sh
     bash ./configure --without-mysql
@@ -147,17 +146,6 @@ function Install_Deps() {
 }
 
 UtilsInit
-
-LogMsg "Updating test case state to running"
-SetTestStateRunning
-
-if [ -e ./${CONSTANTS_FILE} ]; then
-    source ${CONSTANTS_FILE}
-else
-    LogErr "Error: no ${CONSTANTS_FILE} file"
-    SetTestStateAborted
-    exit 0
-fi
 
 pushd $ROOT_DIR
 

--- a/Testscripts/Linux/utils.sh
+++ b/Testscripts/Linux/utils.sh
@@ -1780,7 +1780,7 @@ function GetOSVersion {
         os_CODENAME=""
         for r in "Red Hat" CentOS Fedora XenServer; do
             os_VENDOR=$r
-            if [[ -n "$(grep \"$r\" /etc/redhat-release)" ]]; then
+            if [[ -n $(grep "${r}" "/etc/redhat-release") ]]; then
                 ver=$(sed -e 's/^.* \([0-9].*\) (\(.*\)).*$/\1\|\2/' /etc/redhat-release)
                 os_CODENAME=${ver#*|}
                 os_RELEASE=${ver%|*}


### PR DESCRIPTION
Various code cleanup and fixes:
- Removed sourcing of constants.file (it is performed by default in UtilsInit function)
- Fixed a few occurences of /root folder being used instead of /home/$user
- Fixed GetOSVersion function in utils.sh
- Removed whitespaces

Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:5

   ID TestCaseName                                                                TestResult TestDuration(in minutes)
---------------------------------------------------------------------------------------------------------------------
    1 KVP-BASIC-CHECKS                                                                  PASS                 3.12

Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:10

   ID TestCaseName                                                                TestResult TestDuration(in minutes)
---------------------------------------------------------------------------------------------------------------------
    1 NET-VXLAN                                                                         PASS                 7.88

Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:7

   ID TestCaseName                                                                TestResult TestDuration(in minutes)
---------------------------------------------------------------------------------------------------------------------
    1 NET-COPY-LARGE-FILE                                                               PASS                 4.99


    5 STORAGE-SCSI-DYNAMIC-LARGE-DISK                                                   PASS                 4.87
    6 STORAGE-VHDX-SCSI-DYNAMIC-LARGE-16TB                                              PASS                 4.67
    7 STORAGE-VHDX-SCSI-DYNAMIC-LARGE-64TB                                              PASS                 4.92
