### PR TITLE
xfstests: Removed mount options for XFS FS

### DIFF
--- a/XML/TestCases/CommunityTests.xml
+++ b/XML/TestCases/CommunityTests.xml
@@ -8,7 +8,6 @@
             <param>FSTYP=xfs</param>
             <param>TEST_DEV=/dev/sdc1</param>
             <param>TEST_DIR=/root/test</param>
-            <param>TEST_FS_MOUNT_OPTS='-o nobarrier'</param>
             <param>GENERIC=yes</param>
         </TestParameters>
         <Platform>Azure</Platform>
@@ -26,7 +25,6 @@
             <param>FSTYP=xfs</param>
             <param>TEST_DEV=/dev/sdc1</param>
             <param>TEST_DIR=/root/test</param>
-            <param>TEST_FS_MOUNT_OPTS='-o nobarrier'</param>
         </TestParameters>
         <Platform>Azure</Platform>
         <Category>Community</Category>

--- a/XML/TestCases/FunctionalTests-NVME.xml
+++ b/XML/TestCases/FunctionalTests-NVME.xml
@@ -99,7 +99,6 @@
             <param>FSTYP=xfs</param>
             <param>TEST_DEV=/dev/nvme0n1p1</param>
             <param>TEST_DIR=/root/test</param>
-            <param>TEST_FS_MOUNT_OPTS='-o nobarrier'</param>
             <param>NVME=yes</param>
             <param>GENERIC=yes</param>
         </TestParameters>
@@ -119,7 +118,6 @@
             <param>FSTYP=xfs</param>
             <param>TEST_DEV=/dev/nvme0n1p1</param>
             <param>TEST_DIR=/root/test</param>
-            <param>TEST_FS_MOUNT_OPTS='-o nobarrier'</param>
             <param>NVME=yes</param>
         </TestParameters>
         <Platform>Azure</Platform>


### PR DESCRIPTION
## Description
'nobarrier' mount option is not supported on some distros with xfs filesystem

### PR information
Removed TEST_FS_MOUNT_OPTS from XML files (NVME and Community tests) for XFS/Generic test cases.
### Before PR
FILE-SYSTEM-VERIFICATION-TESTS-GENERIC                                            FAIL                 6.14 
FILE-SYSTEM-VERIFICATION-TESTS-XFS                                                FAIL                 6.55 

root@LISAv2-OneVM1Disk-staging-TG25-20190226080244-role-0:/home/lisa/xfstests# ./check -g generic/quick -E exclude.txt
mount: /root/test: wrong fs type, bad option, bad superblock on /dev/sdc1, missing codepage or helper program, or other error.
common/rc: retrying test device mount with external set
mount: /root/test: wrong fs type, bad option, bad superblock on /dev/sdc1, missing codepage or helper program, or other error.
common/rc: could not mount /dev/sdc1 on /root/test

### After PR:
  ID TestCaseName                                                                TestResult TestDuration(in minutes)
---------------------------------------------------------------------------------------------------------------------
    1 NVME-FILE-SYSTEM-VERIFICATION-GENERIC                                             PASS                49.06
    2 NVME-FILE-SYSTEM-VERIFICATION-XFS                                                 PASS                29.51
    3 NVME-FILE-SYSTEM-VERIFICATION-EXT4                                                PASS                 7.85
    4 NVME-FILE-SYSTEM-VERIFICATION-BTRFS                                               PASS                13.55

### Quality of Code and Contribution Guidelines
- [x] I have read the [contribution guidelines](https://github.com/LIS/LISAv2/blob/master/.github/CONTRIBUTING.md).