### PR TITLE
install_fio: Added noninteractive var

### DIFF
--- a/Testscripts/Linux/utils.sh
+++ b/Testscripts/Linux/utils.sh
@@ -2370,6 +2370,7 @@ function install_fio () {
 			;;
 
 		ubuntu|debian)
+			export DEBIAN_FRONTEND=noninteractive
 			dpkg_configure
 			apt-get install -y pciutils gawk mdadm wget sysstat blktrace bc fio
 			check_exit_status "install_fio"


### PR DESCRIPTION
## Description

In ubuntu/debian we might get a package install prompt that will make the fio test hang.
Adding this variable solves this.

### The VM was stuck at this:
Get:8 http://azure.archive.ubuntu.com/ubuntu/ trusty/main ssl-cert all 1.0.33 [16.6 kB]
Get:9 http://azure.archive.ubuntu.com/ubuntu/ trusty-updates/main postfix amd64 2.11.0-1ubuntu1.2 [1,088 kB]
Get:10 http://azure.archive.ubuntu.com/ubuntu/ trusty/main sysstat amd64 10.2.0-1 [283 kB]
Preconfiguring packages ...

### After the code fix, it gets past that part:
root@LISAv2~# cat TestExecution.log
Fri Mar 01 11:57:38 2019 : Warning: summary file /root/summary.log either does not exist or is not a regular file. Trying to create it...
Fri Mar 01 11:57:38 2019 : **install_fio: Success**
Fri Mar 01 11:57:38 2019 : INFO: Check and remove RAID first
Fri Mar 01 11:57:38 2019 : INFO: Creating Partitions

---

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x] If applicable, the PR references the bug/issue that it fixes in the description.
- [x] Verify PR checker results and fix any coding errors.
- [x] Included LISAv2 sample test results to demonstrate code functionality.

### Quality of Code and Contribution Guidelines
- [x] I have read the [contribution guidelines](https://github.com/LIS/LISAv2/blob/master/.github/CONTRIBUTING.md).