### PR TITLE
SR-IOV: Disable VF on dependency VM (Hyper-V)

### DIFF
--- a/Testscripts/Windows/SRIOV-DISABLEVF-PING.ps1
+++ b/Testscripts/Windows/SRIOV-DISABLEVF-PING.ps1
@@ -41,12 +41,17 @@ function Main {
     }
     Write-LogInfo "The RTT before disabling SR-IOV is $vfEnabledRTT ms"
 
-    # Disable SR-IOV on test VM
+    # Disable SR-IOV on test VM and dependency VM
     Start-Sleep -s 5
     Write-LogInfo "Disabling VF on vm1"
     Set-VMNetworkAdapter -VMName $VMName -ComputerName $HvServer -IovWeight 0
     if (-not $?) {
         Write-LogErr "Failed to disable SR-IOV on $VMName!"
+        return "FAIL"
+    }
+    Set-VMNetworkAdapter -VMName $DependencyVmName -ComputerName $DependencyVmHost -IovWeight 0
+    if (-not $?) {
+        Write-LogErr "Failed to disable SR-IOV on $DependencyVmName!"
         return "FAIL"
     }
 
@@ -66,10 +71,15 @@ function Main {
         return "FAIL"
     }
 
-    # Enable SR-IOV on test VM
+    # Enable SR-IOV on test VM and dependency VM
     Set-VMNetworkAdapter -VMName $VMName -ComputerName $HvServer -IovWeight 1
     if (-not $?) {
         Write-LogErr "Failed to enable SR-IOV on $VMName!"
+        return "FAIL"
+    }
+    Set-VMNetworkAdapter -VMName $DependencyVmName -ComputerName $DependencyVmHost -IovWeight 1
+    if (-not $?) {
+        Write-LogErr "Failed to enable SR-IOV on $DependencyVmName!"
         return "FAIL"
     }
 


### PR DESCRIPTION
Following test case discussions, it was agreed that we need to disable VF on dependency VMs too, not only on the main VMs. This changes all "DISABLEVF" SR-IOV Hyper-V scripts by disabling the VF on the dependency VM. This helps getting bigger deltas between SR-IOV disabled and enabled

## Before this commit
02/20/2019 14:06:34 : [INFO ] The throughput before disabling SR-IOV is 19.4 Gbits/sec
02/20/2019 14:09:13 : [INFO ] **The throughput with SR-IOV disabled is 14.3 Gbits/sec**
02/20/2019 14:10:50 : [INFO ] The throughput after re-enabling SR-IOV is 18.6 Gbits/sec

## After this commit
03/05/2019 08:21:54 : [INFO ] The throughput before disabling SR-IOV is 14.1 Gbits/sec
03/05/2019 08:22:31 : [INFO ] **The throughput with SR-IOV disabled is 7.76 Gbits/sec**
03/05/2019 08:23:07 : [INFO ] The throughput after re-enabling SR-IOV is 15.3 Gbits/sec

## Test results
Total Test Cases      : 3 (3 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:22

   ID TestCaseName                                                                TestResult TestDuration(in minutes)
---------------------------------------------------------------------------------------------------------------------
    1 SRIOV-DISABLEVF-PING                                                              PASS                 5.65
    2 SRIOV-DISABLEVF-IPERF                                                             PASS                  6.5
    3 SRIOV-DISABLEVF-ONHOST                                                            PASS                  8.5

<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Issue # <!-- if any -->
<!--
Please add an informative description that covers that changes made by the pull request.
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x] If applicable, the PR references the bug/issue that it fixes in the description.
- [x] Verify PR checker results and fix any coding errors.
- [x] Included LISAv2 sample test results to demonstrate code functionality.

### Quality of Code and Contribution Guidelines
- [x] I have read the [contribution guidelines](https://github.com/LIS/LISAv2/blob/master/.github/CONTRIBUTING.md).