### PR TITLE
dpdk_ovs: exit on failure

### DIFF
--- a/Testscripts/Linux/dpdk_generic_setup.sh
+++ b/Testscripts/Linux/dpdk_generic_setup.sh
@@ -24,11 +24,11 @@ function setup_huge_pages () {
 	LogMsg "Huge page setup is running"
 	ssh "${1}" "mkdir -p /mnt/huge && mkdir -p /mnt/huge-1G"
 	ssh "${1}" "mount -t hugetlbfs nodev /mnt/huge && mount -t hugetlbfs nodev /mnt/huge-1G -o 'pagesize=1G'"
-	check_exit_status "Huge pages are mounted on ${1}"
+	check_exit_status "Huge pages are mounted on ${1}" "exit"
 	ssh "${1}" "echo 4096 > /sys/devices/system/node/node0/hugepages/hugepages-2048kB/nr_hugepages"
-	check_exit_status "4KB huge pages are configured on ${1}"
+	check_exit_status "4KB huge pages are configured on ${1}" "exit"
 	ssh "${1}" "echo 8 > /sys/devices/system/node/node0/hugepages/hugepages-1048576kB/nr_hugepages"
-	check_exit_status "1GB huge pages are configured on ${1}"
+	check_exit_status "1GB huge pages are configured on ${1}" "exit"
 }
 
 function install_dpdk () {
@@ -61,7 +61,7 @@ function install_dpdk () {
 		LogMsg "Installing DPDK from source file $dpdkSrcTar"
 		ssh "${1}" "wget $dpdkSrcLink -P /tmp"
 		ssh "${1}" "tar xf /tmp/$dpdkSrcTar"
-		check_exit_status "tar xf /tmp/$dpdkSrcTar on ${1}"
+		check_exit_status "tar xf /tmp/$dpdkSrcTar on ${1}" "exit"
 		dpdkSrcDir="${dpdkSrcTar%%".tar"*}"
 		LogMsg "dpdk source on ${1} $dpdkSrcDir"
 		ssh "${1}" "mv ${dpdkSrcDir} ${RTE_SDK}"
@@ -70,7 +70,7 @@ function install_dpdk () {
 		dpdkSrcDir="${dpdkSrcLink##*/}"
 		LogMsg "Installing DPDK from source file $dpdkSrcDir"
 		ssh "${1}" git clone "$dpdkSrcLink"
-		check_exit_status "git clone $dpdkSrcLink on ${1}"
+		check_exit_status "git clone $dpdkSrcLink on ${1}" "exit"
 		LogMsg "dpdk source on ${1} $dpdkSrcDir"
 	else
 		LogMsg "Provide proper link $dpdkSrcLink"
@@ -78,11 +78,11 @@ function install_dpdk () {
 
 	LogMsg "MLX_PMD flag enabling on ${1}"
 	ssh "${1}" "sed -ri 's,(MLX._PMD=)n,\1y,' ${RTE_SDK}/config/common_base"
-	check_exit_status "sed -ri 's,(MLX._PMD=)n,\1y,' ${RTE_SDK}/config/common_base"
+	check_exit_status "sed -ri 's,(MLX._PMD=)n,\1y,' ${RTE_SDK}/config/common_base" "exit"
 	ssh "${1}" "cd ${RTE_SDK} && make config O=${RTE_TARGET} T=${RTE_TARGET}"
 	LogMsg "Starting DPDK build make on ${1}"
 	ssh "${1}" "cd ${RTE_SDK}/${RTE_TARGET} && make -j16 && make install"
-	check_exit_status "dpdk build on ${1}"
+	check_exit_status "dpdk build on ${1}" "exit"
 	LogMsg "*********INFO: Installed DPDK version on ${1} is ${dpdkVersion} ********"
 }
 

--- a/Testscripts/Linux/ovs_setup.sh
+++ b/Testscripts/Linux/ovs_setup.sh
@@ -24,7 +24,7 @@ UtilsInit
 function install_ovs () {
 	SetTestStateRunning
 	LogMsg "Configuring ${1} ${DISTRO_NAME} ${DISTRO_VERSION} for OVS test..."
-	packages=(gcc make git tar wget dos2unix psmisc make)
+	packages=(gcc make git tar wget dos2unix psmisc make iperf3)
 	case "${DISTRO_NAME}" in
 		ubuntu|debian)
 			ssh "${1}" "until dpkg --force-all --configure -a; sleep 10; do echo 'Trying again...'; done"
@@ -51,7 +51,7 @@ function install_ovs () {
 		LogMsg "Installing OVS from source file $ovsSrcTar"
 		ssh "${1}" "wget $ovsSrcLink -P /tmp"
 		ssh "${1}" "tar xf /tmp/$ovsSrcTar"
-		check_exit_status "tar xf /tmp/$ovsSrcTar on ${1}"
+		check_exit_status "tar xf /tmp/$ovsSrcTar on ${1}" "exit"
 		ovsSrcDir="${ovsSrcTar%%".tar"*}"
 		LogMsg "ovs source on ${1} $ovsSrcDir"
 		ssh "${1}" "mv ${ovsSrcDir} ${OVS_DIR}"
@@ -60,7 +60,7 @@ function install_ovs () {
 		ovsSrcDir="${ovsSrcLink##*/}"
 		LogMsg "Installing OVS from source file $ovsSrcDir"
 		ssh "${1}" git clone "$ovsSrcLink"
-		check_exit_status "git clone $ovsSrcLink on ${1}"
+		check_exit_status "git clone $ovsSrcLink on ${1}" "exit"
 		LogMsg "ovs source on ${1} $ovsSrcLink"
 	else
 		LogMsg "Provide proper link $ovsSrcLink"
@@ -73,13 +73,15 @@ function install_ovs () {
 
 	LogMsg "Starting OVS build on ${1}"
 	ssh "${1}" "cd ${OVS_DIR} && make -j16 && make install"
-	check_exit_status "ovs build on ${1}"
+	check_exit_status "ovs build on ${1}" "exit"
+
+	vf_ip=$(ssh "${1}" "ip a | grep ${nicName} -A 2| grep inet | grep ${nicName} | awk '{print \$2}'")
 
 	ssh "${1}" "ip addr flush dev ${nicName}"
-	check_exit_status "${nicName} flush on ${1}"
+	check_exit_status "${nicName} flush on ${1}" "exit"
 
 	ssh "${1}" "/usr/share/openvswitch/scripts/ovs-ctl start"
-	check_exit_status "ovs start on ${1}"
+	check_exit_status "ovs start on ${1}" "exit"
 
 	ssh "${1}" "ovs-vsctl --no-wait set Open_vSwitch . other_config:dpdk-init=true"
 	ssh "${1}" "ovs-vsctl --no-wait set Open_vSwitch . other_config:dpdk-lcore-mask=0xFF"
@@ -87,10 +89,13 @@ function install_ovs () {
 
 	OVS_BRIDGE="br-dpdk"
 	ssh "${1}" "ovs-vsctl add-br "${OVS_BRIDGE}" -- set bridge "${OVS_BRIDGE}" datapath_type=netdev"
-	check_exit_status "ovs bridge ${OVS_BRIDGE} create on ${1}"
+	check_exit_status "ovs bridge ${OVS_BRIDGE} create on ${1}" "exit"
 
 	ssh "${1}" "ovs-vsctl add-port "${OVS_BRIDGE}" p1 -- set Interface p1 type=dpdk options:dpdk-devargs=net_tap_vsc0,iface=${nicName}"
-	check_exit_status "ovs port added to bridge ${OVS_BRIDGE} on ${1}"
+	check_exit_status "ovs port added to bridge ${OVS_BRIDGE} on ${1}" "exit"
+
+	ssh "${1}" "ifconfig ${OVS_BRIDGE} ${vf_ip} up"
+	check_exit_status "set IP ${vf_ip} for ${OVS_BRIDGE} on ${1}" "exit"
 
 	LogMsg "*********INFO: Installed OVS version on ${1} is ${ovsVersion} ********"
 }
@@ -111,8 +116,6 @@ then
 	LogMsg "Skip OVS setup on server"
 	SetTestStateCompleted
 else
-	LogMsg "INFO: Configuring huge pages on server ${server}..."
-	setup_huge_pages "${server}"
 	LogMsg "INFO: Installing OVS on server ${server}..."
 	install_ovs "${server}"
 	SetTestStateCompleted


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Small fixes for the OVS DPDK functional test, making sure the installation fails if an exit code is non zero.

---

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x] If applicable, the PR references the bug/issue that it fixes in the description.
- [x] Verify PR checker results and fix any coding errors.
- [x] Included LISAv2 sample test results to demonstrate code functionality.

### Quality of Code and Contribution Guidelines
- [x] I have read the [contribution guidelines](https://github.com/LIS/LISAv2/blob/master/.github/CONTRIBUTING.md).