### PR TITLE
Marked few LIS tests as SKIPPED instead of ABORTED if the kernel is not upgraded

### DIFF
--- a/Testscripts/Windows/LIS-INSTALL-SCENARIOS.ps1
+++ b/Testscripts/Windows/LIS-INSTALL-SCENARIOS.ps1
@@ -158,7 +158,7 @@ Function Uninstall-LIS ( $LISTarballUrlCurrent, $allVMData , $TestProvider) {
 Function Upgrade-Kernel ($allVMData, $TestProvider, [switch]$RestartAfterUpgrade){
     try {
         Write-LogInfo "Upgrading kernel"
-        Run-LinuxCmd -ip $allVMData.PublicIP -port $allVMData.SSHPort -username "root" -password $password -command "yum install -y kernel >> ~/kernel_install_scenario.log" -runMaxAllowedTime 20000
+        Run-LinuxCmd -ip $allVMData.PublicIP -port $allVMData.SSHPort -username "root" -password $password -command "yum install -y kernel >> ~/kernel_install_scenario.log" -runMaxAllowedTime 600 -maxRetryCount 3
         # Checking if latest kernel is already installed
         $sts = Run-LinuxCmd -ip $allVMData.PublicIP -port $allVMData.SSHPort -username "root" -password $password -command "cat kernel_install_scenario.log | grep 'already installed'" -ignoreLinuxExitCode:$true
         if ($sts) {
@@ -276,7 +276,7 @@ Function Install-LIS-Scenario-4 ($PreviousTestResult, $LISTarballUrlOld, $LISTar
     if ($PreviousTestResult -eq "PASS") {
         $UpgradekernelStatus=Upgrade-Kernel -allVMData $AllVMData -TestProvider $TestProvider
         if (-not $UpgradekernelStatus) {
-            return "FAIL"
+            return "SKIPPED"
         }
         $LISInstallStatus=Install-LIS -LISTarballUrl $LISTarballUrlCurrent -allVMData $AllVMData
         if ($LISInstallStatus -ne $false) {
@@ -306,7 +306,7 @@ Function Install-LIS-Scenario-5 ($PreviousTestResult, $LISTarballUrlOld, $LISTar
         Write-LogInfo "LIS version before upgrading kernel: $LIS_version_before_upgrade_kernel"
         $UpgradekernelStatus=Upgrade-Kernel -allVMData $AllVMData -TestProvider $TestProvider -RestartAfterUpgrade
         if (-not $UpgradekernelStatus) {
-            return "FAIL"
+            return "SKIPPED"
         }
         $LIS_version_after_upgrade_kernel = Run-LinuxCmd -ip $allVMData.PublicIP -port $allVMData.SSHPort -username "root" -password $password -command "modinfo hv_vmbus"
         Write-LogInfo "LIS version after upgrading kernel: $LIS_version_after_upgrade_kernel"
@@ -341,7 +341,7 @@ Function Install-LIS-Scenario-6 ($PreviousTestResult, $LISTarballUrlOld, $LISTar
         Write-LogInfo "LIS version before upgrading kernel: $LIS_version_before_upgrade_kernel"
         $UpgradekernelStatus=Upgrade-Kernel -allVMData $AllVMData -TestProvider $TestProvider -RestartAfterUpgrade
         if (-not $UpgradekernelStatus) {
-            return "FAIL"
+            return "SKIPPED"
         }
         $LIS_version_after_upgrade_kernel = Run-LinuxCmd -ip $allVMData.PublicIP -port $allVMData.SSHPort -username "root" -password $password -command "modinfo hv_vmbus"
         Write-LogInfo "LIS version after upgrading kernel: $LIS_version_after_upgrade_kernel"
@@ -368,7 +368,7 @@ Function Install-LIS-Scenario-7 ($PreviousTestResult, $LISTarballUrlOld, $LISTar
         $is_oracle = Run-LinuxCmd -ip $allVMData.PublicIP -port $allVMData.SSHPort -username "root" -password $password -command "cat /etc/os-release | grep -i oracle" -ignoreLinuxExitCode:$true
         if ($is_oracle) {
             Write-LogErr "Skipped: Oracle not suported on this TC"
-            return "ABORTED"
+            return "SKIPPED"
         }
         Write-LogInfo "Upgrading minor kernel"
         $kernel_version_before_upgrade = Run-LinuxCmd -ip $allVMData.PublicIP -port $allVMData.SSHPort -username "root" -password $password -command "uname -r"
@@ -381,7 +381,7 @@ Function Install-LIS-Scenario-7 ($PreviousTestResult, $LISTarballUrlOld, $LISTar
             Write-LogInfo "kernel version after upgrade: $kernel_version_after_upgrade"
             if ( $kernel_version_after_upgrade -eq $kernel_version_before_upgrade) {
                 Write-LogErr "Failed to Upgrade Minor kernel"
-                return "FAIL"
+                return "SKIPPED"
             }
             Write-LogInfo "Sucessfully Upgraded Minor Kernel"
             $UpgradeStatus=Upgrade-LIS -LISTarballUrlOld $LISTarballUrlOld -LISTarballUrlCurrent $LISTarballUrlCurrent -allVMData $AllVMData -TestProvider $TestProvider -RestartAfterUpgrade


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
In LIS deploy scenario tests, we have some tests where we first install the the latest kernel and then go for LIS installation.
Before this commit : 
If latest / minor kernel installation fails, LISAv2 marks the test as ABORTED.

After this commit : 
If latest / minor kernel installation fails, LISAv2 marks the test as SKIPPED.

<!--
Please add an informative description that covers that changes made by the pull request.
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] Verify PR checker results and fix any coding errors.
- [ ] Included LISAv2 sample test results to demonstrate code functionality.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/LIS/LISAv2/blob/master/.github/CONTRIBUTING.md).