### PR TITLE
dpdk: enable dpdk_ovs on Ubuntu 16 and fix dpdkSetup.sh with git repos

### DIFF
--- a/Testscripts/Linux/dpdk_generic_setup.sh
+++ b/Testscripts/Linux/dpdk_generic_setup.sh
@@ -63,7 +63,6 @@ function install_dpdk () {
 		check_exit_status "tar xf /tmp/$dpdkSrcTar on ${1}" "exit"
 		dpdkSrcDir="${dpdkSrcTar%%".tar"*}"
 		LogMsg "dpdk source on ${1} $dpdkSrcDir"
-		ssh "${1}" "mv ${dpdkSrcDir} ${RTE_SDK}"
 	elif [[ $dpdkSrcLink =~ ".git" ]] || [[ $dpdkSrcLink =~ "git:" ]];
 	then
 		dpdkSrcDir="${dpdkSrcLink##*/}"
@@ -74,6 +73,8 @@ function install_dpdk () {
 	else
 		LogMsg "Provide proper link $dpdkSrcLink"
 	fi
+
+	ssh "${1}" "mv ${dpdkSrcDir} ${RTE_SDK}"
 
 	LogMsg "MLX_PMD flag enabling on ${1}"
 	ssh "${1}" "sed -ri 's,(MLX._PMD=)n,\1y,' ${RTE_SDK}/config/common_base"

--- a/Testscripts/Linux/dpdk_generic_setup.sh
+++ b/Testscripts/Linux/dpdk_generic_setup.sh
@@ -38,11 +38,10 @@ function install_dpdk () {
 	case "${DISTRO_NAME}" in
 		ubuntu|debian)
 			ssh "${1}" "until dpkg --force-all --configure -a; sleep 10; do echo 'Trying again...'; done"
-			if [[ "${DISTRO_VERSION}" != "18.04" ]];
+			if [[ "${DISTRO_VERSION}" == "16.04" ]];
 			then
-				echo "Distro unsupported ${DISTRO_VERSION}"
-				SetTestStateAborted
-				exit 1
+				LogMsg "Adding dpdk repo to ${DISTRO_NAME} ${DISTRO_VERSION} for DPDK test..."
+				ssh "${1}" "add-apt-repository ppa:canonical-server/dpdk-azure -y"
 			fi
 			ssh "${1}" ". ${UTIL_FILE} && update_repos"
 			packages+=(build-essential libnuma-dev libmnl-dev libibverbs-dev autoconf libtool)

--- a/Testscripts/Linux/ovs_setup.sh
+++ b/Testscripts/Linux/ovs_setup.sh
@@ -28,12 +28,6 @@ function install_ovs () {
 	case "${DISTRO_NAME}" in
 		ubuntu|debian)
 			ssh "${1}" "until dpkg --force-all --configure -a; sleep 10; do echo 'Trying again...'; done"
-			if [[ "${DISTRO_VERSION}" != "18.04" ]];
-			then
-				echo "Distro unsupported ${DISTRO_VERSION}"
-				SetTestStateAborted
-				exit 1
-			fi
 			ssh "${1}" ". ${UTIL_FILE} && update_repos"
 			packages+=(autoconf libtool)
 			;;


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Enable dpdk and ovs setup on Ubuntu 16.04.
Fixes the rest of dpdk tests when using a git repo as dpdk source.

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] Verify PR checker results and fix any coding errors.
- [ ] Included LISAv2 sample test results to demonstrate code functionality.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/LIS/LISAv2/blob/master/.github/CONTRIBUTING.md).