### PR TITLE
dpdk: add option to install dpdk from ppa

### DIFF
--- a/Testscripts/Linux/dpdkSetup.sh
+++ b/Testscripts/Linux/dpdkSetup.sh
@@ -93,6 +93,20 @@ function install_dpdk () {
 		check_exit_status "git clone $dpdkSrcLink on ${1}" "exit"
 		cd "$dpdkSrcDir"
 		LogMsg "dpdk source on ${1} $dpdkSrcDir"
+	elif [[ $dpdkSrcLink =~ "ppa:" ]];
+	then
+		if [[ $DISTRO_NAME != "ubuntu" && $DISTRO_NAME != "debian" ]];
+		then
+			echo "PPAs are supported only on Debian based distros."
+			SetTestStateAborted
+			exit 1
+		fi
+		ssh "${1}" "add-apt-repository ${dpdkSrcLink} -y"
+		ssh "${1}" ". ${UTIL_FILE} && update_repos"
+		ssh "${1}" ". ${UTIL_FILE} && install_package dpdk"
+		check_exit_status "Install DPDK from ppa ${dpdkSrcLink} on ${1}" "exit"
+		LogMsg "*********Installed DPDK on ${1}********"
+		return
 	else
 		LogMsg "Provide proper link $dpdkSrcLink"
 	fi


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
On Ubuntu, we need to test out the DPDK version from a special ppa.
Now, you can provide the dpdk source link as a ppa link.

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] Verify PR checker results and fix any coding errors.
- [ ] Included LISAv2 sample test results to demonstrate code functionality.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/LIS/LISAv2/blob/master/.github/CONTRIBUTING.md).