### PR TITLE
Added support to push VMGeneration in telemetry database

### DIFF
--- a/Libraries/Database.psm1
+++ b/Libraries/Database.psm1
@@ -25,7 +25,7 @@
 #>
 ###############################################################################################
 
-Function Get-SQLQueryOfTelemetryData ($TestPlatform,$TestLocation,$TestCategory,$TestArea,$TestName,$CurrentTestResult, `
+Function Get-SQLQueryOfTelemetryData ($TestPlatform,$VMGeneration,$TestLocation,$TestCategory,$TestArea,$TestName,$CurrentTestResult, `
 									$ExecutionTag,$GuestDistro,$KernelVersion,$LISVersion,$HostVersion,$VMSize, `
 									$Networking,$ARMImageName,$OsVHD,$LogFile,$BuildURL)
 {
@@ -50,8 +50,8 @@ Function Get-SQLQueryOfTelemetryData ($TestPlatform,$TestLocation,$TestCategory,
 			$BuildURL = ""
 		}
 		$dataTableName = "LISAv2Results"
-		$SQLQuery = "INSERT INTO $dataTableName (DateTimeUTC,TestPlatform,TestLocation,TestCategory,TestArea,TestName,TestResult,SubTestName,SubTestResult,ExecutionTag,GuestDistro,KernelVersion,LISVersion,HostVersion,VMSize,Networking,ARMImage,OsVHD,LogFile,BuildURL) VALUES "
-		$SQLQuery += "('$DateTimeUTC','$TestPlatform','$TestLocation','$TestCategory','$TestArea','$TestName','$testResult','','','$ExecutionTag','$GuestDistro','$KernelVersion','$LISVersion','$HostVersion','$VMSize','$Networking','$ARMImageName','$OsVHD','$UploadedURL', '$BuildURL'),"
+		$SQLQuery = "INSERT INTO $dataTableName (DateTimeUTC,TestPlatform,VMGeneration,TestLocation,TestCategory,TestArea,TestName,TestResult,SubTestName,SubTestResult,ExecutionTag,GuestDistro,KernelVersion,LISVersion,HostVersion,VMSize,Networking,ARMImage,OsVHD,LogFile,BuildURL) VALUES "
+		$SQLQuery += "('$DateTimeUTC','$TestPlatform','$VMGeneration','$TestLocation','$TestCategory','$TestArea','$TestName','$testResult','','','$ExecutionTag','$GuestDistro','$KernelVersion','$LISVersion','$HostVersion','$VMSize','$Networking','$ARMImageName','$OsVHD','$UploadedURL', '$BuildURL'),"
 		if ($TestSummary) {
 			foreach ($tempResult in $TestSummary.Split('>')) {
 				if ($tempResult) {

--- a/Libraries/TestLogs.psm1
+++ b/Libraries/TestLogs.psm1
@@ -198,7 +198,7 @@ Function Get-SystemBasicLogs($AllVMData, $User, $Password, $currentTestData, $Cu
 		}
 		#endregion
 		if ($enableTelemetry) {
-			$SQLQuery = Get-SQLQueryOfTelemetryData -TestPlatform $global:TestPlatform -TestLocation $global:TestLocation -TestCategory $CurrentTestData.Category `
+			$SQLQuery = Get-SQLQueryOfTelemetryData -TestPlatform $global:TestPlatform -VMGeneration $global:VMGeneration -TestLocation $global:TestLocation -TestCategory $CurrentTestData.Category `
 			-TestArea $CurrentTestData.Area -TestName $CurrentTestData.TestName -CurrentTestResult $CurrentTestResult `
 			-ExecutionTag $global:GlobalConfig.$TestPlatform.ResultsDatabase.testTag -GuestDistro $GuestDistro -KernelVersion $KernelVersion `
 			-LISVersion $LISVersion -HostVersion $HostVersion -VMSize $VMSize -Networking $Networking `


### PR DESCRIPTION
As we are moving to fully automate PowerBI reports, we need a support to view results with more granularity. 

This PR adds one more such property to telemetry database -  "VMGeneration"